### PR TITLE
Fix user tokens not cleared on logout if `IdentityManager` is not available

### DIFF
--- a/Example/Tests/Configuration.swift
+++ b/Example/Tests/Configuration.swift
@@ -34,7 +34,7 @@ class SchibstedAccountConfiguration: QuickConfiguration {
             Utils.cleanupKeychain()
             PasswordlessTokenStore.clear()
 
-            expect(User.globalStore.count) == 0
+            expect(User.globalStore.count).toEventually(equal(0))
 
             OwnedTaskHandle.counter.value = 0
 

--- a/Example/Tests/IdentityManagerTests.swift
+++ b/Example/Tests/IdentityManagerTests.swift
@@ -77,6 +77,18 @@ class IdentityManagerTests: QuickSpec {
                 expect(newTokens?.refreshToken).to(equal(tokens?.refreshToken))
                 expect(newTokens?.idToken).to(equal(tokens?.idToken))
             }
+
+            it("Should clear the keychain on logout") {
+                Utils.createDummyKeychain()
+                let user = Utils.makeIdentityManager().currentUser
+                expect(user.state).to(equal(UserState.loggedIn))
+                user.logout()
+
+                let tokens = UserTokensKeychain().data().first
+                expect(tokens?.accessToken).to(beNil())
+                expect(tokens?.refreshToken).to(beNil())
+                expect(tokens?.idToken).to(beNil())
+            }
         }
 
         describe("Send code for passwordless signup") {

--- a/SchibstedAccount/Manager/IdentityManager.swift
+++ b/SchibstedAccount/Manager/IdentityManager.swift
@@ -109,9 +109,7 @@ public class IdentityManager: IdentityManagerProtocol {
         self.currentUser = User(clientConfiguration: clientConfiguration)
         self.currentUser.delegate = self
 
-        if let tokens = try? UserTokensStorage().loadTokens() {
-            self.finishLogin(result: .success(tokens), completion: nil)
-        }
+        try? self.currentUser.loadStoredTokens()
 
         log(from: self, "user: \(self.currentUser)")
     }

--- a/SchibstedAccount/Manager/IdentityManager.swift
+++ b/SchibstedAccount/Manager/IdentityManager.swift
@@ -113,20 +113,7 @@ public class IdentityManager: IdentityManagerProtocol {
             self.finishLogin(result: .success(tokens), completion: nil)
         }
 
-        self.currentUser.didSetTokens.register(self, handler: type(of: self).userDidSetTokens).descriptionText = "IdentityManager.userDidSetTokens"
-
         log(from: self, "user: \(self.currentUser)")
-    }
-
-    private func userDidSetTokens(_ tokens: (new: TokenData?, old: TokenData?)) {
-        // Always clear old tokens
-        if let previousUserTokens = tokens.old {
-            try? UserTokensStorage().clear(previousUserTokens)
-        }
-
-        if tokens.new != nil, let currentUserTokens = self.currentUser.tokens {
-            try? UserTokensStorage().store(currentUserTokens)
-        }
     }
 
     private func dispatchIfSelf(_ block: @escaping () -> Void) {

--- a/SchibstedAccount/Manager/User/User.swift
+++ b/SchibstedAccount/Manager/User/User.swift
@@ -218,6 +218,16 @@ public class User: UserProtocol {
         }
     }
 
+    func loadStoredTokens() throws {
+        let tokens = try UserTokensStorage().loadTokens()
+        try self.set(
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            idToken: tokens.idToken,
+            userID: tokens.userID
+        )
+    }
+
     func updateStoredTokens(_ tokens: TokenData?, previousTokens: TokenData?) {
         // Always clear old tokens
         if let previousUserTokens = previousTokens {


### PR DESCRIPTION
Take # 2 🎬