### PR TITLE
Refactor: add common ShowTermsCoordinator

### DIFF
--- a/SchibstedAccount.xcodeproj/project.pbxproj
+++ b/SchibstedAccount.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D5A7FFE208DF0F800B5D21F /* ShowTermsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5A7FFD208DF0F800B5D21F /* ShowTermsCoordinator.swift */; };
 		0DE37BF4207B625700110614 /* UserTermsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE37BF3207B625700110614 /* UserTermsInteractor.swift */; };
 		0DFBB1342068ECEB0055F6B8 /* UpdatedTermsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DFBB1212068ECEB0055F6B8 /* UpdatedTermsCoordinator.swift */; };
 		43C24192205BF1BF00154866 /* SchibstedAccount.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43C24188205BF1BE00154866 /* SchibstedAccount.framework */; };
@@ -444,6 +445,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0D5A7FFD208DF0F800B5D21F /* ShowTermsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowTermsCoordinator.swift; sourceTree = "<group>"; };
 		0DE37BF3207B625700110614 /* UserTermsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTermsInteractor.swift; sourceTree = "<group>"; };
 		0DFBB1212068ECEB0055F6B8 /* UpdatedTermsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdatedTermsCoordinator.swift; sourceTree = "<group>"; };
 		43C24188205BF1BE00154866 /* SchibstedAccount.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SchibstedAccount.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1082,6 +1084,7 @@
 				B01D783ED1F2B73B7CE6F8A5 /* AuthenticationCoordinator.swift */,
 				B01D739FA5AC38261ED7F6D5 /* CompleteProfileCoordinator.swift */,
 				0DFBB1212068ECEB0055F6B8 /* UpdatedTermsCoordinator.swift */,
+				0D5A7FFD208DF0F800B5D21F /* ShowTermsCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -1831,6 +1834,7 @@
 				B01D7B7BE2BAD7D47776B7A6 /* User+Agreements.swift in Sources */,
 				B01D7D4BBB9590376EAA738C /* TokenData+anyUserID.swift in Sources */,
 				B01D7F932357AF608B43570E /* FetchTermsTask.swift in Sources */,
+				0D5A7FFE208DF0F800B5D21F /* ShowTermsCoordinator.swift in Sources */,
 				43E15FE62063B24000D9BA3E /* LogoView.swift in Sources */,
 				B01D786509649C0694D68D76 /* TokenExchangeTask.swift in Sources */,
 				B01D733F76A227C1B49808FC /* FetchRequiredFields.swift in Sources */,

--- a/Source/UI/Coordinators/CompleteProfileCoordinator.swift
+++ b/Source/UI/Coordinators/CompleteProfileCoordinator.swift
@@ -181,7 +181,7 @@ extension CompleteProfileCoordinator {
         completion: @escaping (AgreementsAcceptanceResult) -> Void
     ) {
         let showTermsCoordinator = ShowTermsCoordinator(navigationController: self.navigationController, configuration: self.configuration)
-        let input = ShowTermsCoordinator.Input(terms: terms, loginFlowVariant: loginFlowVariant, presentationStyle: .pushToExistingNavigationFlow)
+        let input = ShowTermsCoordinator.Input(terms: terms, loginFlowVariant: loginFlowVariant)
 
         self.child = ChildFlowCoordinator(showTermsCoordinator, input: input) { [weak self] output in
             self?.child = nil

--- a/Source/UI/Coordinators/ShowTermsCoordinator.swift
+++ b/Source/UI/Coordinators/ShowTermsCoordinator.swift
@@ -7,23 +7,8 @@ import UIKit
 
 class ShowTermsCoordinator: FlowCoordinator {
     struct Input {
-        enum PresentationStyle {
-            case replaceNavigationFlow
-            case pushToExistingNavigationFlow
-
-            fileprivate var hasBackButton: Bool {
-                switch self {
-                case .replaceNavigationFlow:
-                    return false
-                case .pushToExistingNavigationFlow:
-                    return true
-                }
-            }
-        }
-
         let terms: Terms
         let loginFlowVariant: LoginMethod.FlowVariant
-        let presentationStyle: PresentationStyle
     }
 
     enum Output {
@@ -46,7 +31,6 @@ class ShowTermsCoordinator: FlowCoordinator {
         self.showAcceptTermsView(
             for: input.terms,
             loginFlowVariant: input.loginFlowVariant,
-            presentationStyle: input.presentationStyle,
             completion: completion
         )
     }
@@ -56,12 +40,13 @@ extension ShowTermsCoordinator {
     private func showAcceptTermsView(
         for terms: Terms,
         loginFlowVariant: LoginMethod.FlowVariant,
-        presentationStyle: Input.PresentationStyle,
         completion: @escaping (Output) -> Void
     ) {
+        let isFirstViewController = self.navigationController.viewControllers.count == 0
+
         let navigationSettings = NavigationSettings(
             cancel: { completion(.cancel) },
-            back: presentationStyle.hasBackButton ? { completion(.back) } : nil
+            back: isFirstViewController ? nil : { completion(.back) }
         )
         let viewModel = TermsViewModel(
             terms: terms,
@@ -86,11 +71,10 @@ extension ShowTermsCoordinator {
             }
         }
 
-        switch presentationStyle {
-        case .pushToExistingNavigationFlow:
-            self.navigationController.pushViewController(viewController, animated: true)
-        case .replaceNavigationFlow:
+        if isFirstViewController {
             self.navigationController.viewControllers = [viewController]
+        } else {
+            self.navigationController.pushViewController(viewController, animated: true)
         }
     }
 

--- a/Source/UI/Coordinators/ShowTermsCoordinator.swift
+++ b/Source/UI/Coordinators/ShowTermsCoordinator.swift
@@ -1,0 +1,102 @@
+//
+// Copyright 2011 - 2018 Schibsted Products & Technology AS.
+// Licensed under the terms of the MIT license. See LICENSE in the project root.
+//
+
+import UIKit
+
+class ShowTermsCoordinator: FlowCoordinator {
+    struct Input {
+        enum PresentationStyle {
+            case replaceNavigationFlow
+            case pushToExistingNavigationFlow
+
+            fileprivate var hasBackButton: Bool {
+                switch self {
+                case .replaceNavigationFlow:
+                    return false
+                case .pushToExistingNavigationFlow:
+                    return true
+                }
+            }
+        }
+
+        let terms: Terms
+        let loginFlowVariant: LoginMethod.FlowVariant
+        let presentationStyle: PresentationStyle
+    }
+
+    enum Output {
+        case success
+        case cancel
+        case back
+    }
+
+    let navigationController: UINavigationController
+    let configuration: IdentityUIConfiguration
+
+    var child: ChildFlowCoordinator?
+
+    init(navigationController: UINavigationController, configuration: IdentityUIConfiguration) {
+        self.navigationController = navigationController
+        self.configuration = configuration
+    }
+
+    func start(input: Input, completion: @escaping (Output) -> Void) {
+        self.showAcceptTermsView(
+            for: input.terms,
+            loginFlowVariant: input.loginFlowVariant,
+            presentationStyle: input.presentationStyle,
+            completion: completion
+        )
+    }
+}
+
+extension ShowTermsCoordinator {
+    private func showAcceptTermsView(
+        for terms: Terms,
+        loginFlowVariant: LoginMethod.FlowVariant,
+        presentationStyle: Input.PresentationStyle,
+        completion: @escaping (Output) -> Void
+    ) {
+        let navigationSettings = NavigationSettings(
+            cancel: { completion(.cancel) },
+            back: presentationStyle.hasBackButton ? { completion(.back) } : nil
+        )
+        let viewModel = TermsViewModel(
+            terms: terms,
+            loginFlowVariant: loginFlowVariant,
+            appName: self.configuration.appName,
+            localizationBundle: self.configuration.localizationBundle
+        )
+
+        let viewController = TermsViewController(configuration: self.configuration, navigationSettings: navigationSettings, viewModel: viewModel)
+        viewController.didRequestAction = { [weak self] action in
+            switch action {
+            case .acceptTerms:
+                completion(.success)
+            case let .learnMore(summary):
+                self?.showTermsSummaryView(summary)
+            case let .open(url):
+                self?.present(url: url)
+            case .back:
+                completion(.back)
+            case .cancel:
+                completion(.cancel)
+            }
+        }
+
+        switch presentationStyle {
+        case .pushToExistingNavigationFlow:
+            self.navigationController.pushViewController(viewController, animated: true)
+        case .replaceNavigationFlow:
+            self.navigationController.viewControllers = [viewController]
+        }
+    }
+
+    private func showTermsSummaryView(_ summary: String) {
+        let viewModel = TermsSummaryViewModel(summary: summary, localizationBundle: self.configuration.localizationBundle)
+        let viewController = TermsSummaryViewController(configuration: self.configuration, viewModel: viewModel)
+        self.presentAsPopup(viewController)
+    }
+}

--- a/Source/UI/Coordinators/UpdatedTermsCoordinator.swift
+++ b/Source/UI/Coordinators/UpdatedTermsCoordinator.swift
@@ -38,7 +38,7 @@ class UpdatedTermsCoordinator: FlowCoordinator {
 extension UpdatedTermsCoordinator {
     private func spawnShowTermsCoordinator(with terms: Terms, userTermsInteractor: UserTermsInteractor, completion: @escaping (Output) -> Void) {
         let showTermsCoordinator = ShowTermsCoordinator(navigationController: self.navigationController, configuration: self.configuration)
-        let input = ShowTermsCoordinator.Input(terms: terms, loginFlowVariant: .signin, presentationStyle: .replaceNavigationFlow)
+        let input = ShowTermsCoordinator.Input(terms: terms, loginFlowVariant: .signin)
 
         self.child = ChildFlowCoordinator(showTermsCoordinator, input: input) { [weak self] output in
             self?.child = nil

--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -152,17 +152,8 @@ public class IdentityUI {
         let input = UpdatedTermsCoordinator.Input(currentUser: user, terms: terms)
 
         self.updatedTermsCoordinator = UpdatedTermsCoordinator(navigationController: navigationController, configuration: configuration)
-        self.updatedTermsCoordinator?.start(input: input) { output in
+        self.updatedTermsCoordinator?.start(input: input) { _ in
             self.updatedTermsCoordinator = nil
-
-            switch output {
-            case .success:
-                break
-            case .cancel:
-                // Since user has not accepted the updated terms, we force a logout :'(
-                user.logout()
-            }
-
             navigationController.dismiss(animated: true, completion: nil)
         }
         configuration.presentationHook?(navigationController)


### PR DESCRIPTION
Add a `ShowTermsCoordinator` that is used by both `CompleteProfileCoordinator` and `UpdatedTermsCoordinator`. This was originally intended for #56, but might be useful regardless, as it should make changing the terms screen simpler by providing it from a single place.