### PR TITLE
Make the statics that hold on to UI processes weak

### DIFF
--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -109,9 +109,9 @@ public class IdentityUI {
     // Used to store the currently presented identity process so that:
     // 1. The presentation of one process at a time can be enforced.
     // 2. When handling a universal link, the currently presented process (if any) can be retrieved.
-    private static var presentedIdentityUI: IdentityUI?
+    private weak static var presentedIdentityUI: IdentityUI?
 
-    private static var updatedTermsCoordinator: UpdatedTermsCoordinator?
+    private weak static var updatedTermsCoordinator: UpdatedTermsCoordinator?
 
     /**
      Present a screen where the user can review and accept updated terms and conditions.


### PR DESCRIPTION
This is so that if the UIFlow is dismissed without `didFinish` being
called, there is no retain cycle