### PR TITLE
Handle premature dismissal of Identity UI

### DIFF
--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -132,7 +132,11 @@ public class IdentityUI {
     ///
     public let identityManager: IdentityManager
 
-    let navigationController = UINavigationController()
+    lazy var navigationController: UINavigationController = {
+        DismissableNavigationController { [weak self] in
+            self?.complete(with: .cancel)
+        }
+    }()
 
     var child: ChildFlowCoordinator?
 
@@ -291,6 +295,11 @@ public class IdentityUI {
     }
 
     private func complete(with output: Output) {
+        guard IdentityUI.presentedIdentityUI != nil else {
+            // IdentityUI has been already dismissed.
+            return
+        }
+
         let uiResult: IdentityUIResult?
         switch output {
         case let .success(user):


### PR DESCRIPTION
By intercepting viewDidDisappear and firing a completion with `.cancel` result in case the client dismissed the UI out of the SDK control.