### PR TITLE
Fixed aborting flow to call the cancel instead of "onlyDismiss"

### DIFF
--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -294,8 +294,6 @@ public class IdentityUI {
             uiResult = .canceled
         case .skip:
             uiResult = .skipped
-        case .onlyDismiss:
-            uiResult = nil
         case let .failure(error):
             uiResult = .failed(error)
         }
@@ -339,7 +337,6 @@ extension IdentityUI: FlowCoordinator {
     enum Output {
         case success(User)
         case cancel
-        case onlyDismiss
         case failure(ClientError)
         case skip
     }
@@ -463,7 +460,7 @@ extension IdentityUI {
                         )
                     case let .abort(shouldDismiss):
                         if shouldDismiss {
-                            self?.complete(with: .onlyDismiss)
+                            self?.complete(with: .cancel)
                         }
                     case let .showError(title, description):
                         self?.presentError(title: title, description: description)


### PR DESCRIPTION
onlyDimiss doesn't call the delegate completion callback, and it
doesn't look like we need it