### PR TITLE
Added: Adds support for username/password autofill

### DIFF
--- a/Source/UI/Screens/Identifier/IdentifierViewController.swift
+++ b/Source/UI/Screens/Identifier/IdentifierViewController.swift
@@ -61,6 +61,10 @@ class IdentifierViewController: IdentityUIViewController {
             self.emailAddress.delegate = self
             self.emailAddress.isHidden = true
             self.emailAddress.clearButtonMode = .whileEditing
+
+            if #available(iOS 11.0, *) {
+                self.emailAddress.textContentType = .username
+            }
         }
     }
     @IBOutlet var phoneNumber: TextField! {

--- a/Source/UI/Screens/Password/PasswordViewController.swift
+++ b/Source/UI/Screens/Password/PasswordViewController.swift
@@ -110,6 +110,10 @@ class PasswordViewController: IdentityUIViewController {
             self.password.delegate = self
             self.password.clearButtonMode = .whileEditing
             self.password.isSecureTextEntry = true
+
+            if #available(iOS 11.0, *) {
+                self.password.textContentType = .password
+            }
         }
     }
     @IBOutlet var inputTitle: NormalLabel! {


### PR DESCRIPTION
# What?
Sets the `textContentType` on the username and password text fields.

# Why?
This enables us to utilize the autofill function provided by Apple as seen at [WWDC 2017](https://developer.apple.com/videos/play/wwdc2017/206/). 