### PR TITLE
Changed: Store tokens with accessmode kSecAttrAccessibleAfterFirstUnlock to allow background access.

### DIFF
--- a/Source/Manager/SwiftKeychain.swift
+++ b/Source/Manager/SwiftKeychain.swift
@@ -48,7 +48,7 @@ protocol KeychainItemType {
 
 extension KeychainItemType {
     var accessMode: String {
-        return String(kSecAttrAccessibleWhenUnlocked)
+        return String(kSecAttrAccessibleAfterFirstUnlock)
     }
 
     var accessGroup: String? {
@@ -62,6 +62,7 @@ extension KeychainItemType {
         let archivedData = NSKeyedArchiver.archivedData(withRootObject: dataToStore)
 
         itemAttributes[String(kSecValueData)] = archivedData
+        itemAttributes[String(kSecAttrAccessible)] = accessMode
 
         if let group = accessGroup {
             itemAttributes[String(kSecAttrAccessGroup)] = group
@@ -88,6 +89,14 @@ extension KeychainItemType {
 
         return itemAttributes
     }
+
+    internal var attributesForDelete: [String: Any] {
+        var itemAttributes = attributes
+        if let group = accessGroup {
+            itemAttributes[String(kSecAttrAccessGroup)] = group
+        }
+        return itemAttributes
+    }
 }
 
 // MARK: - KeychainGenericPasswordType
@@ -106,7 +115,6 @@ extension KeychainGenericPasswordType {
         var attributes = [String: Any]()
 
         attributes[String(kSecClass)] = kSecClassGenericPassword
-        attributes[String(kSecAttrAccessible)] = accessMode
         attributes[String(kSecAttrService)] = serviceName
         attributes[String(kSecAttrAccount)] = accountName
 
@@ -118,18 +126,19 @@ extension KeychainGenericPasswordType {
 
 struct Keychain: KeychainServiceType {
     internal func errorForStatusCode(_ statusCode: OSStatus) -> NSError {
-        return NSError(domain: "swift.keychain.error", code: Int(statusCode), userInfo: nil)
+        var userInfo: [String: Any]?
+        if #available(iOS 11.3, *) {
+            if let errorMessage = SecCopyErrorMessageString(statusCode, nil) {
+                userInfo = [NSLocalizedDescriptionKey: errorMessage]
+            }
+        }
+        return NSError(domain: "swift.keychain.error", code: Int(statusCode), userInfo: userInfo)
     }
 
     // Inserts or updates a keychain item with attributes
 
     public func insertItemWithAttributes(_ attributes: [String: Any]) throws {
-        var statusCode = SecItemAdd(attributes as CFDictionary, nil)
-
-        if statusCode == errSecDuplicateItem {
-            SecItemDelete(attributes as CFDictionary)
-            statusCode = SecItemAdd(attributes as CFDictionary, nil)
-        }
+        let statusCode = SecItemAdd(attributes as CFDictionary, nil)
 
         if statusCode != errSecSuccess {
             throw self.errorForStatusCode(statusCode)
@@ -165,11 +174,13 @@ struct Keychain: KeychainServiceType {
 
 extension KeychainItemType {
     func saveInKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
+        // Remove any old value before inserting
+        try? removeFromKeychain(keychain)
         try keychain.insertItemWithAttributes(self.attributesToSave)
     }
 
     func removeFromKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
-        try keychain.removeItemWithAttributes(attributes)
+        try keychain.removeItemWithAttributes(self.attributesForDelete)
     }
 
     mutating func fetchFromKeychain(_ keychain: KeychainServiceType = Keychain()) throws -> Self {

--- a/Source/Manager/SwiftKeychain.swift
+++ b/Source/Manager/SwiftKeychain.swift
@@ -175,7 +175,7 @@ struct Keychain: KeychainServiceType {
 extension KeychainItemType {
     func saveInKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
         // Remove any old value before inserting
-        try? removeFromKeychain(keychain)
+        try? self.removeFromKeychain(keychain)
         try keychain.insertItemWithAttributes(self.attributesToSave)
     }
 

--- a/Tests/UserTokensKeychainTests.swift
+++ b/Tests/UserTokensKeychainTests.swift
@@ -43,7 +43,6 @@ func loadWithPreviousKeychainLayout() throws -> TokenData {
     var attributes = [String: Any]()
 
     attributes[String(kSecClass)] = kSecClassGenericPassword
-    attributes[String(kSecAttrAccessible)] = String(kSecAttrAccessibleWhenUnlocked)
     attributes[String(kSecAttrService)] = "swift.keychain.service"
     attributes[String(kSecAttrAccount)] = "SchibstedID"
     attributes[String(kSecReturnData)] = kCFBooleanTrue


### PR DESCRIPTION
**Problem**

If a killed app receives a push notifications with `content-available` set to `1`, and the app allows background mode, the app will be launched in the background by the system. 
If the device is locked when this happens - reads to keychain values with  `kSecAttrAccessibleWhenUnlocked` will fail with an error `Access to item attempted while keychain is locked.`.

If the app is relying on the state of the User logged in state as part of the launch of the app - that state will then signal that there are no access tokens stored, meaning the user is signed out.

We've been experiencing this problem at Blocket with users getting signed out, as they receive push notifications for messages.

**Proposed solution**

Rather than storing values to only be read while the device is unlocked, use the  `kSecAttrAccessibleAfterFirstUnlock` instead. As described by Apple:

> After the first unlock, the data remains accessible until the next restart. This is recommended for items that need to be accessed by background applications. Items with this attribute migrate to a new device when using encrypted backups.

This pull request does this change. And also changes the way duplicate values are handled.
In the previous code, the `kSecAttrAccessGroup` was included in attributes used for read, write and delete. When changing the value however, this will fail when you try to delete the value as the `kSecAttrAccessGroup` will differ from the previously stored value.

Instead, here, the deletion of a "duplicate" is moved to `saveInKeychain` where you try to delete the value first before inserting the new one. The attributes for deletion will not include the `kSecAttrAccessGroup`.