### PR TITLE
Logout all similar users in global store

### DIFF
--- a/Source/Core/SynchronizedDictionary.swift
+++ b/Source/Core/SynchronizedDictionary.swift
@@ -38,7 +38,7 @@ class SynchronizedDictionary<K: Hashable, V> {
        onlyIf { // check some conditions related to $0 }
      )
      */
-    func removeValue(forKey key: K, onlyIf predicate: (V) -> Bool) -> V? {
+    func removeValue(forKey key: K, if predicate: (V) -> Bool) -> V? {
         var maybeValue: V?
         self.dispatchQueue.sync {
             guard let value = self.dictionary[key] else {
@@ -50,6 +50,14 @@ class SynchronizedDictionary<K: Hashable, V> {
             }
         }
         return maybeValue
+    }
+
+    func forEach(_ callback: @escaping (K, V) -> Void) {
+        self.dispatchQueue.async(flags: .barrier) {
+            for (key, val) in self.dictionary {
+                callback(key, val)
+            }
+        }
     }
 
     var count: Int {

--- a/Source/Core/SynchronizedWeakDictionary.swift
+++ b/Source/Core/SynchronizedWeakDictionary.swift
@@ -26,7 +26,7 @@ class SynchronizedWeakDictionary<K: Hashable, V: AnyObject> {
             self.dictionary[key] = WeakValue(newValue)
         }
         get {
-            guard let weakValue = self.dictionary.removeValue(forKey: key, onlyIf: { $0.value == nil }) else {
+            guard let weakValue = self.dictionary.removeValue(forKey: key, if: { $0.value == nil }) else {
                 return nil
             }
             return weakValue.value
@@ -39,5 +39,9 @@ class SynchronizedWeakDictionary<K: Hashable, V: AnyObject> {
 
     func removeAll(keepingCapacity keepCapacity: Bool = false) {
         self.dictionary.removeAll(keepingCapacity: keepCapacity)
+    }
+
+    func forEach(_ callback: @escaping (K, WeakValue<V>) -> Void) {
+        self.dictionary.forEach(callback)
     }
 }


### PR DESCRIPTION
Some clients use headless and visual login. This is necessary if
you want to implemente web credentials for e.g. since it's not
supported in the visual login flow.

So there could be multiple User instances in the global store if
logins occur via different methods (visual and headless) and if
there're any User objects lying around.

This patch just makes sure all the other User instance's tokens
are clearned if any one User instance calls logout