### PR TITLE
Fixed: cancellation of tasks to "finish" an NSOperation

### DIFF
--- a/Source/Manager/TaskManager/TaskManager.swift
+++ b/Source/Manager/TaskManager/TaskManager.swift
@@ -214,7 +214,13 @@ class TaskManager {
 
                 log(level: .debug, from: self, "unsuspending queue")
                 strongSelf.operationQueue.isSuspended = false
-                strongSelf.operationQueue.addOperations(strongSelf.operationsToReAdd, waitUntilFinished: false)
+
+                // handle.cancel could have been called in which case the operation is "finished"
+                // And you can't add a finished operation to the queue.
+                strongSelf.operationQueue.addOperations(
+                    strongSelf.operationsToReAdd.filter { !$0.isFinished },
+                    waitUntilFinished: false
+                )
                 strongSelf.operationsToReAdd.removeAll()
             } catch {
                 strongSelf.lock.lock()

--- a/Source/Manager/TaskManager/TaskOperation.swift
+++ b/Source/Manager/TaskManager/TaskOperation.swift
@@ -111,4 +111,9 @@ class TaskOperation: Operation {
         didChangeValue(forKey: KVOKey.isExecuting.rawValue)
         didChangeValue(forKey: KVOKey.isFinished.rawValue)
     }
+
+    open override func cancel() {
+        super.cancel()
+        self.finish()
+    }
 }


### PR DESCRIPTION
Seems like that was handled by accident only because we would
check isCancelled is TaskOperation.start