### PR TITLE
Changed: Move token refresh retry limit to SDKConfiguration.

### DIFF
--- a/Source/Manager/Protocols/UserAuthAPI.swift
+++ b/Source/Manager/Protocols/UserAuthAPI.swift
@@ -8,8 +8,6 @@ import Foundation
 ///
 public protocol UserAuthAPI: class {
     ///
-    var refreshRetryCount: Int? { get set }
-    ///
     @discardableResult
     func oneTimeCode(clientID: String, completion: @escaping StringResultCallback) -> TaskHandle
     ///

--- a/Source/Manager/SDKConfiguration/SDKConfiguration.swift
+++ b/Source/Manager/SDKConfiguration/SDKConfiguration.swift
@@ -37,6 +37,27 @@ public class SDKConfiguration {
         self.agreementsCache = .default
     }
 
+    /**
+     When you send out a request associated with a user access token and it returns with a 401, the `User` is refreshed and
+     the request is refired with a new set of auth tokens. In the case that your request still comes back with a 401,
+     even though the tokens were just refreshed and should be valid, an infinite loop can ensue. This variable controls
+     how many times it should retry a request that previously came back with a 401. If the count is exceeded
+     then you get back whatever the response and data was from the actual request, and the error will be
+     `ClientError.RefreshRetryExceededCode` with the NSUnderlyingErrorKey set to actual request error (if there was one)
+
+     - note default = 1
+     */
+    public var refreshRetryCount: Int? {
+        get {
+            let value = self._refreshRetryCount.value
+            return value == 0 ? nil : value
+        }
+        set(newValue) {
+            self._refreshRetryCount.value = newValue ?? 0
+        }
+    }
+    private var _refreshRetryCount = AtomicInt(1)
+
     #if DEBUG
     /**
      Set this to debug access token and refreshing requests. If set to true then every successful request

--- a/Source/Manager/TaskManager/TaskManager.swift
+++ b/Source/Manager/TaskManager/TaskManager.swift
@@ -153,7 +153,7 @@ class TaskManager {
             }
 
             // If retry count exceeded, cancel it, we're done
-            if let maxRetryCount = user.auth.refreshRetryCount,
+            if let maxRetryCount = SDKConfiguration.shared.refreshRetryCount,
                 taskData.retryCount >= maxRetryCount,
                 let data = self.pendingTasks.removeValue(forKey: handle) {
                 log(level: .warn, from: self, "refresh retry count for \(handle) exceeeded")

--- a/Source/Manager/User/User+Auth.swift
+++ b/Source/Manager/User/User+Auth.swift
@@ -13,27 +13,6 @@ extension User {
         weak var user: UserProtocol?
 
         /**
-         When you send out a request associated with this user and it returns with a 401, the `User` is refreshed and
-         the the request is refired with a new set of auth tokens. In the case that your request still comes back with a 401,
-         even though the tokens were just refreshed and should be valid, an infinite loop can ensue. This variable controls
-         how many times it should retry a request that previously came back with a 401. If the count is exceeded
-         then you get back whatever the response and data was from the actual request, and the error will be
-         `ClientError.RefreshRetryExceededCode` with the NSUnderlyingErrorKey set to actual request error (if there was one)
-
-         - note default = 1
-         */
-        public var refreshRetryCount: Int? {
-            get {
-                let value = self._refreshRetryCount.value
-                return value == 0 ? nil : value
-            }
-            set(newValue) {
-                self._refreshRetryCount.value = newValue ?? 0
-            }
-        }
-        private var _refreshRetryCount = AtomicInt(1)
-
-        /**
          Get a one-time API authentication code for the current user.
 
          This code can be sent to a different API, or a different SDK (for example a JS SDK),

--- a/Tests/AutoRefreshURLProtocolTests.swift
+++ b/Tests/AutoRefreshURLProtocolTests.swift
@@ -215,7 +215,7 @@ class AutoRefreshURLProtocolTests: QuickSpec {
             let user = TestingUser(state: .loggedIn)
             let session = URLSession(user: user, configuration: URLSessionConfiguration.default)
 
-            user.auth.refreshRetryCount = nil
+            SDKConfiguration.shared.refreshRetryCount = nil
 
             var tasks: [URLSessionTask] = []
             var doneCounter = 0

--- a/Tests/Configuration.swift
+++ b/Tests/Configuration.swift
@@ -59,6 +59,8 @@ class SchibstedAccountConfiguration: QuickConfiguration {
             Settings.clearAll()
 
             Logger.shared.waitTillAllLogsTransported()
+
+            SDKConfiguration.shared.refreshRetryCount = 1
         }
     }
 }

--- a/Tests/URLSessionTests.swift
+++ b/Tests/URLSessionTests.swift
@@ -198,7 +198,7 @@ class URLSessionTests: QuickSpec {
 
             it("Should handle butt loads of requests") {
                 let (session, user) = Utils.makeURLSession()
-                user.auth.refreshRetryCount = nil // don't error on refresh retries
+                SDKConfiguration.shared.refreshRetryCount = nil // don't error on refresh retries
                 Utils.hold(user)
 
                 let wantedUrl = "http://www.example.com/"
@@ -258,7 +258,7 @@ class URLSessionTests: QuickSpec {
                 StubbedNetworkingProxy.addStub(stubSignup)
 
                 let (session, user) = Utils.makeURLSession()
-                user.auth.refreshRetryCount = 2
+                SDKConfiguration.shared.refreshRetryCount = 2
                 doDataTask(session, url: URL(string: wantedUrl)!) { _, _, error in
                     expect(error).to(matchError(ClientError.userRefreshFailed(kDummyError)))
                     guard let clientError = error as? ClientError, case let ClientError.userRefreshFailed(error) = clientError else {

--- a/Tests/Utils/TestingUser.swift
+++ b/Tests/Utils/TestingUser.swift
@@ -14,15 +14,6 @@ class TestingUserAuth: UserAuthAPI {
         self.wrapped = auth
     }
 
-    var refreshRetryCount: Int? {
-        get {
-            return self.wrapped.refreshRetryCount
-        }
-        set {
-            self.wrapped.refreshRetryCount = newValue
-        }
-    }
-
     func oneTimeCode(clientID: String, completion: @escaping StringResultCallback) -> TaskHandle {
         return Utils.waitUntilDone(completion) { [unowned self] in
             self.wrapped.oneTimeCode(clientID: clientID, completion: $0)


### PR DESCRIPTION
Since this change is backwards incompatible, it'll go into version 2.0 (skipping deprecation, then removal as in #224).