### PR TITLE
Revert "Fixed: cancellation of tasks to "finish" an NSOperation"

### DIFF
--- a/Source/Manager/TaskManager/TaskManager.swift
+++ b/Source/Manager/TaskManager/TaskManager.swift
@@ -214,13 +214,7 @@ class TaskManager {
 
                 log(level: .debug, from: self, "unsuspending queue")
                 strongSelf.operationQueue.isSuspended = false
-
-                // handle.cancel could have been called in which case the operation is "finished"
-                // And you can't add a finished operation to the queue.
-                strongSelf.operationQueue.addOperations(
-                    strongSelf.operationsToReAdd.filter { !$0.isFinished },
-                    waitUntilFinished: false
-                )
+                strongSelf.operationQueue.addOperations(strongSelf.operationsToReAdd, waitUntilFinished: false)
                 strongSelf.operationsToReAdd.removeAll()
             } catch {
                 strongSelf.lock.lock()

--- a/Source/Manager/TaskManager/TaskOperation.swift
+++ b/Source/Manager/TaskManager/TaskOperation.swift
@@ -100,9 +100,4 @@ class TaskOperation: Operation {
         didChangeValue(forKey: KVOKey.isExecuting.rawValue)
         didChangeValue(forKey: KVOKey.isFinished.rawValue)
     }
-
-    open override func cancel() {
-        super.cancel()
-        self.finish()
-    }
 }


### PR DESCRIPTION
This reverts commit 13f59212cf0902255f35212ce6e757e540fee074.

This seems to be causing problems locally. I think that PR probably needs a bit more work before it's ok.