### PR TITLE
Add retry on network error

### DIFF
--- a/Source/Manager/IdentityAPI/IdentityAPI.swift
+++ b/Source/Manager/IdentityAPI/IdentityAPI.swift
@@ -21,8 +21,7 @@ class IdentityAPI {
 
         let block: ((Result<T, ClientError>) -> Void) = { [weak self] (result) in
             if retry > 0,
-                case .failure(let clientError) = result,
-                case .networkingError(let error) = clientError,
+                case .failure(.networkingError(let error)) = result,
                 (error as NSError).domain == NSURLErrorDomain {
                 self?.requestWithRetries(retry: retry-1,
                                          router: router,

--- a/Source/Manager/IdentityAPI/IdentityAPI.swift
+++ b/Source/Manager/IdentityAPI/IdentityAPI.swift
@@ -34,7 +34,7 @@ class IdentityAPI {
                 completion(result)
             }
         }
-        
+
         let task = request(router: router, formData: formData, headers: headers, parameters: parameters, completion: block)
 
         task?.resume()

--- a/Source/Manager/IdentityAPI/IdentityAPI.swift
+++ b/Source/Manager/IdentityAPI/IdentityAPI.swift
@@ -21,8 +21,9 @@ class IdentityAPI {
 
         let block: ((Result<T, ClientError>) -> Void) = { [weak self] (result) in
             if retry > 0,
-                case .failure(.networkingError(let error)) = result,
-                (error as NSError).domain == NSURLErrorDomain {
+                case .failure(.networkingError(let error as NSError)) = result,
+                error.domain == NSURLErrorDomain &&
+                    error.code == NSURLErrorNetworkConnectionLost {
                 self?.requestWithRetries(retry: retry-1,
                                          router: router,
                                          formData: formData,

--- a/Source/Manager/IdentityAPI/IdentityAPI.swift
+++ b/Source/Manager/IdentityAPI/IdentityAPI.swift
@@ -12,31 +12,56 @@ class IdentityAPI {
         self.basePath = basePath
     }
 
+    func requestWithRetries<T: JSONParsable>(retry: Int = 1,
+                                             router: Router,
+                                             formData: [String: String?] = [:],
+                                             headers: [Networking.Header: String] = [:],
+                                             parameters: [String: String] = [:],
+                                             completion: @escaping ((Result<T, ClientError>) -> Void)) {
+
+        let block: ((Result<T, ClientError>) -> Void) = { [weak self] (result) in
+            if retry > 0,
+                case .failure(let clientError) = result,
+                case .networkingError(let error) = clientError,
+                (error as NSError).domain == NSURLErrorDomain {
+                self?.requestWithRetries(retry: retry-1,
+                                         router: router,
+                                         formData: formData,
+                                         headers: headers,
+                                         parameters: parameters,
+                                         completion: completion)
+            } else {
+                completion(result)
+            }
+        }
+        
+        let task = request(router: router, formData: formData, headers: headers, parameters: parameters, completion: block)
+
+        task?.resume()
+    }
+
     func fetchClient(oauthToken: String, clientID: String, completion: @escaping ((Result<Client, ClientError>) -> Void)) {
-        let task = request(
+        requestWithRetries(
             router: .client(clientID: clientID),
             headers: [.authorization: oauthToken.bearer],
             completion: completion
         )
-        task?.resume()
     }
 
     func fetchAgreementsAcceptanceStatus(oauthToken: String,
                                          userID: String,
                                          completion: @escaping ((Result<Agreements, ClientError>) -> Void)) {
-        let task = request(router: .agreementsStatus(userID: userID),
+        requestWithRetries(router: .agreementsStatus(userID: userID),
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func acceptAgreements(oauthToken: String,
                           userID: String,
                           completion: @escaping ((Result<EmptyResponse, ClientError>) -> Void)) {
-        let task = request(router: .acceptAgreements(userID: userID),
+        requestWithRetries(router: .acceptAgreements(userID: userID),
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func fetchClientAccessToken(clientID: String,
@@ -49,47 +74,42 @@ class IdentityAPI {
                                identifierInBase64: String,
                                connection: Connection,
                                completion: @escaping ((Result<IdentifierStatus, ClientError>) -> Void)) {
-        let task = request(router: .identifierStatus(connection: connection,
+        requestWithRetries(router: .identifierStatus(connection: connection,
                                                      identifierInBase64: identifierInBase64),
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func fetchUserAssets(oauthToken: String,
                          userID: String,
                          completion: @escaping (Result<UserAssets, ClientError>) -> Void) {
-        let task = request(router: .assets(userID: userID),
+        requestWithRetries(router: .assets(userID: userID),
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func fetchUserProfile(userID: String,
                           oauthToken: String,
                           completion: @escaping ((Result<UserProfile, ClientError>) -> Void)) {
-        let task = request(router: .profile(userID: userID),
+        requestWithRetries(router: .profile(userID: userID),
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func fetchUserProduct(oauthToken: String,
                           userID: String,
                           productID: String,
                           completion: @escaping ((Result<UserProduct, ClientError>) -> Void)) {
-        let task = request(router: .product(userID: userID, productID: productID),
+        requestWithRetries(router: .product(userID: userID, productID: productID),
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func logout(oauthToken: String,
                 completion: @escaping ((Result<EmptyResponse, ClientError>) -> Void)) {
-        let task = request(router: .logout,
+        requestWithRetries(router: .logout,
                            headers: [.authorization: oauthToken.bearer],
                            completion: completion)
-        task?.resume()
     }
 
     func requestAccessToken(clientID: String,
@@ -114,8 +134,7 @@ class IdentityAPI {
             "scope": scope?.trimmed().joined(separator: " "),
         ]
 
-        let task = request(router: .oauthToken, formData: formData, completion: completion)
-        task?.resume()
+        requestWithRetries(router: .oauthToken, formData: formData, completion: completion)
     }
 
     func startPasswordless(
@@ -140,9 +159,7 @@ class IdentityAPI {
             formData["email"] = identifier
         }
 
-        let task = request(router: .passwordlessStart, formData: formData, completion: completion)
-
-        task?.resume()
+        requestWithRetries(router: .passwordlessStart, formData: formData, completion: completion)
     }
 
     func resendCode(clientID: String,
@@ -157,8 +174,7 @@ class IdentityAPI {
             "locale": locale,
         ]
 
-        let task = request(router: .passwordlessResend, formData: formData, completion: completion)
-        task?.resume()
+        requestWithRetries(router: .passwordlessResend, formData: formData, completion: completion)
     }
 
     func signup(
@@ -187,8 +203,7 @@ class IdentityAPI {
             formData["acceptTerms"] = acceptTerms ? String(1) : String(0)
         }
 
-        let task = request(router: .signup, formData: formData, headers: [.authorization: oauthToken.bearer], completion: completion)
-        task?.resume()
+        requestWithRetries(router: .signup, formData: formData, headers: [.authorization: oauthToken.bearer], completion: completion)
     }
 
     func tokenExchange(oauthToken: String,
@@ -202,8 +217,7 @@ class IdentityAPI {
             "redirectUri": redirectURI,
         ]
 
-        let task = request(router: .exchangeToken, formData: formData, headers: [.authorization: oauthToken.bearer], completion: completion)
-        task?.resume()
+        requestWithRetries(router: .exchangeToken, formData: formData, headers: [.authorization: oauthToken.bearer], completion: completion)
     }
 
     func updateUserProfile(
@@ -213,8 +227,7 @@ class IdentityAPI {
         completion: @escaping ((Result<UserProfile, ClientError>) -> Void)
     ) {
         let formData = profile.formData()
-        let task = request(router: .updateProfile(userID: userID), formData: formData, headers: [.authorization: oauthToken.bearer], completion: completion)
-        task?.resume()
+        requestWithRetries(router: .updateProfile(userID: userID), formData: formData, headers: [.authorization: oauthToken.bearer], completion: completion)
     }
 
     func validateCode(clientID: String,
@@ -236,18 +249,15 @@ class IdentityAPI {
             "scope": scope.trimmed().joined(separator: " "),
         ]
 
-        let task = request(router: Router.validate, formData: formData, completion: completion)
-        task?.resume()
+        requestWithRetries(router: Router.validate, formData: formData, completion: completion)
     }
 
     func fetchTerms(clientID: String, completion: @escaping TermsResultCallback) {
-        let task = request(router: .terms, parameters: ["client_id": clientID], completion: completion)
-        task?.resume()
+        requestWithRetries(router: .terms, parameters: ["client_id": clientID], completion: completion)
     }
 
     func fetchRequiredFields(oauthToken: String, userID: String, completion: @escaping (Result<RequiredFields, ClientError>) -> Void) {
-        let task = request(router: .requiredFields(userID: userID), headers: [.authorization: oauthToken.bearer], completion: completion)
-        task?.resume()
+        requestWithRetries(router: .requiredFields(userID: userID), headers: [.authorization: oauthToken.bearer], completion: completion)
     }
 
     private static func triviallyParseSpidError(_ error: Error, path: String) -> ClientError? {


### PR DESCRIPTION
I am working on the current Aftonbladet app (the old code base). While fixing parts of the purchase flow for the non-logged-in-state I notice we were receiving a lot of "lost connection"/-1005 errors. The Google answer seem to be that the app drops "Keep-alive" connections (when leaving the app) which when returned becomes a lost connection. This becomes noticeable when leaving Aftonbladet to read and confirm the account creation confirmation email. When tapping confirm and returning to the app will show a "something went wrong" message, but works on a second try. To mitigate this behaviour I added a re-try step in IdentityAPI on just this error. Feel free to ping me in Schibsted slack for questions.