### PR TITLE
Switch to using hash(into:) instead of hashValue from Hashable.

### DIFF
--- a/Source/Core/EventEmitter.swift
+++ b/Source/Core/EventEmitter.swift
@@ -28,8 +28,8 @@ class ReceiverHandle<Parameters>: Hashable {
         self.descriptionText = "block"
     }
 
-    var hashValue: Int {
-        return Unmanaged.passUnretained(self).toOpaque().hashValue
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(Unmanaged.passUnretained(self).toOpaque())
     }
 }
 

--- a/Source/Core/Networking/StubbedNetworkingProxy.swift
+++ b/Source/Core/Networking/StubbedNetworkingProxy.swift
@@ -125,10 +125,10 @@ enum NetworkStubPath: Hashable, CustomStringConvertible {
         }
     }
 
-    var hashValue: Int {
+    func hash(into hasher: inout Hasher) {
         switch self {
-        case let .path(path): return path.hashValue
-        case let .url(url): return url.absoluteString.hashValue
+        case let .path(path): hasher.combine(path)
+        case let .url(url): hasher.combine(url.absoluteString)
         }
     }
 }

--- a/Source/Manager/TaskManager/OwnedTaskHandle.swift
+++ b/Source/Manager/TaskManager/OwnedTaskHandle.swift
@@ -28,8 +28,8 @@ extension OwnedTaskHandle: CustomStringConvertible {
 }
 
 extension OwnedTaskHandle: Hashable {
-    var hashValue: Int {
-        return self.identifier
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.identifier)
     }
 
     static func == (lhs: OwnedTaskHandle, rhs: OwnedTaskHandle) -> Bool {


### PR DESCRIPTION
Due to new rule (legacy_hashing) introduced in [swiftlint 0.29.2](https://github.com/realm/SwiftLint/pull/2496).