### PR TITLE
Add a configuration option for clients to enable/disable touch ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,7 @@ The SDK comes with the following localization support:
 
 #### Touch ID
 
-Starting from version [2.1.0](https://github.com/schibsted/account-sdk-ios/releases/tag/2.1.0) of the SDK, and after a first successful password authentication, i
-users can enroll their Touch ID to later use it in a place of entering their password. It is also **strongly** recommended that users should be able to disable/enable authentication using Touch ID at any time, for which you need to add a UI component (typically a `UISwitch`) to your app settings which calls `IdentityUIConfiguration.useBiometrics`.
+Starting from version [2.1.0](https://github.com/schibsted/account-sdk-ios/releases/tag/2.1.0) of the SDK, and after a first successful password authentication, users can enroll their Touch ID to later use it in a place of entering their password. It is also **strongly** recommended that users should be able to disable/enable authentication using Touch ID at any time, for which you need to add a UI component (typically a `UISwitch`) to your app settings which calls `IdentityUIConfiguration.useBiometrics`.
 
 ### **Headless login with IdentityManager**
 

--- a/Source/UI/Coordinators/PasswordCoordinator.swift
+++ b/Source/UI/Coordinators/PasswordCoordinator.swift
@@ -252,6 +252,7 @@ extension PasswordCoordinator {
     private func canUseBiometrics() -> Bool {
         let context = LAContext()
         guard #available(iOS 11.3, *),
+            configuration.enableBiometrics,
             context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil),
             context.biometryType == .touchID
         else {

--- a/Source/UI/IdentityUIConfiguration.swift
+++ b/Source/UI/IdentityUIConfiguration.swift
@@ -23,6 +23,8 @@ public struct IdentityUIConfiguration {
     public let tracker: TrackingEventsHandler?
     /// This determines whether you want to allow the user to dismiss the login flow
     public let isCancelable: Bool
+    /// This determines whether you want to allow the user to use biometric login
+    public let enableBiometrics: Bool
     /// This determines whether the user wants to use biometric login, defaults to false
     public var useBiometrics: Bool {
         guard let value = Settings.value(forKey: Constants.BiometricsSettingsKey ) as? Bool else {
@@ -67,14 +69,14 @@ public struct IdentityUIConfiguration {
      - parameter tracker: Required implementation of the trackinge events handler
      - parameter localizationBundle: If you have any custom localizations you want to use
      - parameter appName: If you want to customize the app name display in the UI
-     - parameter useBiometrics: If you want to enable biometrics authentication
+     - parameter enableBiometrics: If you want to enable biometrics authentication
     */
     public init(
         clientConfiguration: ClientConfiguration,
         theme: IdentityUITheme = .default,
         isCancelable: Bool = true,
         isSkippable: Bool = false,
-        useBiometrics: Bool? = nil,
+        enableBiometrics: Bool = false,
         presentationHook: ((UIViewController) -> Void)? = nil,
         tracker: TrackingEventsHandler? = nil,
         localizationBundle: Bundle? = nil,
@@ -86,11 +88,11 @@ public struct IdentityUIConfiguration {
         self.isSkippable = isSkippable
         self.presentationHook = presentationHook
         self.localizationBundle = localizationBundle ?? IdentityUI.bundle
+        self.enableBiometrics = enableBiometrics
         self.tracker = tracker
         if let appName = appName {
             self.appName = appName
         }
-        self.useBiometrics(useBiometrics ?? self.useBiometrics)
     }
 
     /**
@@ -103,12 +105,13 @@ public struct IdentityUIConfiguration {
      - parameter tracker: Required implementation of the trackinge events handler
      - parameter localizationBundle: If you have any custom localizations you want to use
      - parameter appName: If you want to customize the app name display in the UI
-     - parameter useBiometrics: If you want to enable biometrics authentication
+     - parameter enableBiometrics: If you want to enable biometrics authentication
     */
     public func replacing(
         theme: IdentityUITheme? = nil,
         isCancelable: Bool? = nil,
         isSkippable: Bool? = nil,
+        enableBiometrics: Bool? = nil,
         useBiometrics: Bool? = nil,
         presentationHook: ((UIViewController) -> Void)? = nil,
         tracker: TrackingEventsHandler? = nil,
@@ -120,7 +123,7 @@ public struct IdentityUIConfiguration {
             theme: theme ?? self.theme,
             isCancelable: isCancelable ?? self.isCancelable,
             isSkippable: isSkippable ?? self.isSkippable,
-            useBiometrics: useBiometrics ?? self.useBiometrics,
+            enableBiometrics: enableBiometrics ?? self.enableBiometrics,
             presentationHook: presentationHook ?? self.presentationHook,
             tracker: tracker ?? self.tracker,
             localizationBundle: localizationBundle ?? self.localizationBundle,
@@ -143,6 +146,7 @@ extension IdentityUIConfiguration: CustomStringConvertible {
         return "(\n\tname: \(self.appName), "
             + "\n\tcancelable: \(self.isCancelable), "
             + "\n\tskippable: \(self.isSkippable), "
+            + "\n\tenableBiometrics: \(self.enableBiometrics), "
             + "\n\tuseBiometrics: \(self.useBiometrics), "
             + "\n\ttracker: \(self.tracker != nil), "
             + "\n\tclient: \(self.clientConfiguration)\n)"


### PR DESCRIPTION
Add a configuration option `enableBiometrics` for clients to enable/disable Biometric login. Note that this is different from `useBiometrics` which holds the user's choice with regard to Biometrics. 