### PR TITLE
Don't call /api/2/logout endpoint on user logout.

### DIFF
--- a/Source/Manager/IdentityAPI/IdentityAPI.swift
+++ b/Source/Manager/IdentityAPI/IdentityAPI.swift
@@ -104,13 +104,6 @@ class IdentityAPI {
                                 completion: completion)
     }
 
-    func logout(oauthToken: String,
-                completion: @escaping ((Result<EmptyResponse, ClientError>) -> Void)) {
-        self.requestWithRetries(router: .logout,
-                                headers: [.authorization: oauthToken.bearer],
-                                completion: completion)
-    }
-
     func requestAccessToken(clientID: String,
                             clientSecret: String,
                             grantType: RequestAccessTokenType,

--- a/Source/Manager/IdentityAPI/Router.swift
+++ b/Source/Manager/IdentityAPI/Router.swift
@@ -19,7 +19,6 @@ enum Router {
     case profile(userID: String)
     case updateProfile(userID: String)
     case terms
-    case logout
     case requiredFields(userID: String)
     case client(clientID: String)
     case product(userID: String, productID: String)
@@ -52,8 +51,6 @@ enum Router {
         case .updateProfile:
             return .POST
         case .terms:
-            return .GET
-        case .logout:
             return .GET
         case .requiredFields:
             return .GET
@@ -110,8 +107,6 @@ enum Router {
             return "/api/2/user/\(userID)"
         case .terms:
             return "/api/2/terms"
-        case .logout:
-            return "/api/2/logout"
         case let .requiredFields(userID):
             return "/api/2/user/\(userID)/required_fields"
         case let .product(userID, productID):

--- a/Source/Manager/User/User.swift
+++ b/Source/Manager/User/User.swift
@@ -177,10 +177,6 @@ public class User: UserProtocol {
                 }
             }
         }
-
-        self.api.logout(oauthToken: oldTokens.accessToken) { [weak self] result in
-            log(level: .verbose, from: self, "logging out - server session result: \(result)")
-        }
     }
 
     private func clearTokens() -> TokenData? {

--- a/Tests/IdentityAPITests.swift
+++ b/Tests/IdentityAPITests.swift
@@ -730,27 +730,6 @@ class IdentityAPITests: QuickSpec {
             }
         }
 
-        describe("logout") {
-            it("should pass in correct data") {
-                let stub = NetworkStub(path: .path(Router.logout.path))
-                StubbedNetworkingProxy.addStub(stub)
-                let api = IdentityAPI(basePath: self.testBasePath)
-
-                waitUntil { done in
-                    api.logout(
-                        oauthToken: self.testOauthToken
-                    ) { _ in
-                        done()
-                    }
-                }
-
-                expect(Networking.testingProxy.calledOnce).to(beTrue())
-                let callData = Networking.testingProxy.calls[0]
-                expect(callData.passedRequest?.allHTTPHeaderFields?["Authorization"]).to(contain(self.testOauthToken))
-                expect(callData.sentHTTPHeaders).to(haveStandardHeadersSet())
-            }
-        }
-
         describe("signup") {
             it("should pass in correct data") {
                 let stub = NetworkStub(path: .path(Router.signup.path))

--- a/Tests/UserTests.swift
+++ b/Tests/UserTests.swift
@@ -101,16 +101,6 @@ class UserTests: QuickSpec {
                     delegate.stateChangedData.count >= 1
                 }
             }
-
-            it("Should fire the API logout call asynchronously") {
-                var stubSignup = NetworkStub(path: .path(Router.logout.path))
-                stubSignup.returnResponse(status: 200)
-                StubbedNetworkingProxy.addStub(stubSignup)
-
-                let user = TestingUser(state: .loggedIn)
-                user.logout()
-                expect(Networking.testingProxy.calledOnce).toEventually(beTrue())
-            }
         }
 
         describe("Setting tokens") {


### PR DESCRIPTION
The endpoint currently does nothing and will be deprecated.