### PR TITLE
Release 2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,4 +235,4 @@ DEPENDENCIES
   slather (>= 2.4.6)
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
This should replace 2.3.0:

- Enable face ID.
- Code & dev updates for Xcode 10.2
- Fix some pods linting warnings.
