### PR TITLE
Added: Allow passing keychain access group to the UserTokensKeychain attributes

### DIFF
--- a/Source/Manager/ClientConfiguration.swift
+++ b/Source/Manager/ClientConfiguration.swift
@@ -117,6 +117,9 @@ public struct ClientConfiguration {
     /// The locale that is being used
     public let locale: Locale
 
+    /// The (optional) keychain access group
+    public let accessGroup: String?
+
     /**
      Which environment (if any) is this configuration using
      */
@@ -135,13 +138,15 @@ public struct ClientConfiguration {
      - parameter clientSecret: the secret associated with the client ID
      - parameter appURLScheme: set your `appURLSceheme` here. Defaults to "spid-\(clientID)" if nil
      - parameter locale: Locale you want to use for requests - defaults to system
+     - parameter accessGroup: The keychain access group - defaults to nil
      */
     public init(
         serverURL: URL,
         clientID: String,
         clientSecret: String,
         appURLScheme: String?,
-        locale: Locale? = nil
+        locale: Locale? = nil,
+        accessGroup: String? = nil
     ) {
         let data = Environment.dataForServerURL(serverURL)
         self.init(
@@ -162,13 +167,15 @@ public struct ClientConfiguration {
         clientID: String,
         clientSecret: String,
         appURLScheme: String?,
-        locale: Locale? = nil
+        locale: Locale? = nil,
+        accessGroup: String? = nil
     ) {
         self.serverURL = serverURL
         self.providerComponent = providerComponent
         self.clientID = clientID
         self.clientSecret = clientSecret
         self.locale = locale ?? Locale.current
+        self.accessGroup = accessGroup
         let defaultAppURLScheme = "spid-\(clientID)"
         self.appURLScheme = appURLScheme ?? defaultAppURLScheme
         self.defaultAppURLScheme = defaultAppURLScheme

--- a/Source/Manager/ClientConfiguration.swift
+++ b/Source/Manager/ClientConfiguration.swift
@@ -156,7 +156,8 @@ public struct ClientConfiguration {
             clientID: clientID,
             clientSecret: clientSecret,
             appURLScheme: appURLScheme,
-            locale: locale
+            locale: locale,
+            accessGroup: accessGroup
         )
     }
 

--- a/Source/Manager/ClientConfiguration.swift
+++ b/Source/Manager/ClientConfiguration.swift
@@ -202,8 +202,9 @@ public struct ClientConfiguration {
      - parameter clientSecret: the secret associated with the client ID
      - parameter appURLScheme: set your `appURLSceheme`. Defaults to "spid-\(clientID)" if nil
      - parameter locale: Locale you want IdentityManager to use for requests
+     - parameter accessGroup: The keychain access group - defaults to nil
      */
-    public init(environment: Environment, clientID: String, clientSecret: String, appURLScheme: String?, locale: Locale? = nil) {
+    public init(environment: Environment, clientID: String, clientSecret: String, appURLScheme: String?, locale: Locale? = nil, accessGroup: String? = nil) {
         let envConfig = environment.loadConfiguration()
         self.init(
             environment: environment,
@@ -212,7 +213,8 @@ public struct ClientConfiguration {
             clientID: clientID,
             clientSecret: clientSecret,
             appURLScheme: appURLScheme,
-            locale: locale
+            locale: locale,
+            accessGroup: accessGroup
         )
     }
 

--- a/Source/Manager/User/User.swift
+++ b/Source/Manager/User/User.swift
@@ -168,7 +168,7 @@ public class User: UserProtocol {
             return
         }
 
-        try? UserTokensStorage().clearAll()
+        try? UserTokensStorage(accessGroup: clientConfiguration.accessGroup).clearAll()
         delegate?.user(self, didChangeStateTo: .loggedOut)
 
         User.globalStore.forEach { _, weakVal in
@@ -264,13 +264,13 @@ public class User: UserProtocol {
             // tokens were then not cleared or some other weird nonsense.
             //
             // TODO: Revisit this logic if and when multi user keychain support is implemented
-            try? UserTokensStorage().clearAll()
+            try? UserTokensStorage(accessGroup: clientConfiguration.accessGroup).clearAll()
         }
 
         if isPersistent {
             // Store new tokens if we are supposed to be persistent.
             // Only clear previous tokens if the user is NOT a new one (since they have not logged out)
-            try? UserTokensStorage().store(newTokens)
+            try? UserTokensStorage(accessGroup: clientConfiguration.accessGroup).store(newTokens)
         }
 
         // Only call state change if we had a previous user and we have a new us
@@ -280,7 +280,7 @@ public class User: UserProtocol {
     }
 
     func loadStoredTokens() throws {
-        let tokens = try UserTokensStorage().loadTokens()
+        let tokens = try UserTokensStorage(accessGroup: clientConfiguration.accessGroup).loadTokens()
         try set(
             accessToken: tokens.accessToken,
             refreshToken: tokens.refreshToken,
@@ -295,7 +295,7 @@ public class User: UserProtocol {
     func persistCurrentTokens() {
         guard !isPersistent, let tokens = self.tokens else { return }
         do {
-            try UserTokensStorage().store(tokens)
+            try UserTokensStorage(accessGroup: clientConfiguration.accessGroup).store(tokens)
             isPersistent = true
         } catch {
             log(level: .error, from: self, "failed to persist tokens: \(error)", force: true)

--- a/Source/Manager/UserTokensKeychain.swift
+++ b/Source/Manager/UserTokensKeychain.swift
@@ -44,6 +44,7 @@ class UserTokensKeychain: KeychainGenericPasswordType {
         return fetchedData
     }
     let accountName = "SchibstedID"
+    let accessGroup: String?
 
     func data() -> [TokenData] {
         guard let loggedInUsers = (try? fetchedData.jsonObject(for: Keys.loggedInUsers)) as? [String: JSONObject] else {
@@ -112,7 +113,8 @@ class UserTokensKeychain: KeychainGenericPasswordType {
         try saveInKeychain()
     }
 
-    init() {
+    init(accessGroup: String? = nil) {
+        self.accessGroup = accessGroup
         var downcastedSelf = self
         if (try? downcastedSelf.fetchFromKeychain()) != nil {
             fetchedData = downcastedSelf.fetchedData

--- a/Source/Manager/UserTokensStorage.swift
+++ b/Source/Manager/UserTokensStorage.swift
@@ -8,10 +8,16 @@ import Foundation
 private let kSPiDAccessToken = "AccessToken"
 
 struct UserTokensStorage {
+    let accessGroup: String?
+
+    init(accessGroup: String? = nil) {
+        self.accessGroup = accessGroup
+    }
+
     func loadTokens() throws -> TokenData {
         let tokens: TokenData
         var areOldTokens = false
-        if let existingTokens = UserTokensKeychain().data().first {
+        if let existingTokens = UserTokensKeychain(accessGroup: accessGroup).data().first {
             tokens = existingTokens
         } else if let oldTokens = SPiDKeychainWrapper.accessTokenFromKeychain(forIdentifier: kSPiDAccessToken), let accessToken = oldTokens.accessToken {
             tokens = TokenData(accessToken: accessToken, refreshToken: oldTokens.refreshToken, idToken: nil, userID: oldTokens.userID)
@@ -35,7 +41,7 @@ struct UserTokensStorage {
     }
 
     func store(_ tokens: TokenData) throws {
-        let keychain = UserTokensKeychain()
+        let keychain = UserTokensKeychain(accessGroup: accessGroup)
         keychain.addTokens(tokens)
 
         do {
@@ -53,7 +59,7 @@ struct UserTokensStorage {
     }
 
     func clear(_ tokens: TokenData) throws {
-        let keychain = UserTokensKeychain()
+        let keychain = UserTokensKeychain(accessGroup: accessGroup)
         keychain.removeTokens(forAccessToken: tokens.accessToken)
 
         do {
@@ -68,7 +74,7 @@ struct UserTokensStorage {
     }
 
     func clearAll() throws {
-        let keychain = UserTokensKeychain()
+        let keychain = UserTokensKeychain(accessGroup: accessGroup)
         keychain.removeAllTokens()
 
         do {


### PR DESCRIPTION
In order to use a shared keychain, apps need to be able to set the `accessGroup` property on the `UserTokensKeychain` in order for it to be used in the attributes passed to `SecItemAdd` in the `SPiDKeychainWrapper`.

This will allow shared authentication between apps on the same Apple team. 