### PR TITLE
Add forgot password to the toolbar

### DIFF
--- a/Source/UI/Screens/Password/PasswordViewController.swift
+++ b/Source/UI/Screens/Password/PasswordViewController.swift
@@ -145,7 +145,13 @@ class PasswordViewController: IdentityUIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let toolbar = UIToolbar.forKeyboard(target: self, doneString: viewModel.done, doneSelector: #selector(didTapContinue))
+        let toolbar = UIToolbar.forKeyboard(
+            target: self,
+            doneString: viewModel.done,
+            doneSelector: #selector(didTapContinue),
+            extraActionSelector: #selector(didTapForgotPassword),
+            extraActionString: viewModel.forgotPassword
+        )
 
         password.inputAccessoryView = toolbar
         viewToEnsureVisibilityOfAfterKeyboardAppearance = password

--- a/Source/UI/Utils/UIToolBar+keyboard.swift
+++ b/Source/UI/Utils/UIToolBar+keyboard.swift
@@ -12,6 +12,8 @@ extension UIToolbar {
         doneSelector: Selector? = nil,
         previousSelector: Selector? = nil,
         nextSelector: Selector? = nil,
+        extraActionSelector: Selector? = nil,
+        extraActionString: String? = nil,
         leftChevronImage: UIImage? = nil
     ) -> UIToolbar {
         let toolbar = UIToolbar()
@@ -33,8 +35,13 @@ extension UIToolbar {
             next = UIBarButtonItem(image: chevronRight, style: .plain, target: target, action: nextSelector)
         }
 
+        var extra: UIBarButtonItem?
+        if let extraActionSelector = extraActionSelector, let extraActionString = extraActionString {
+            extra = UIBarButtonItem(title: extraActionString, style: .done, target: target, action: extraActionSelector)
+        }
+
         let flex = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        toolbar.setItems([previous, next, flex, done].compactOrFlatMap { $0 }, animated: true)
+        toolbar.setItems([previous, next, extra, flex, done].compactOrFlatMap { $0 }, animated: true)
         return toolbar
     }
 }


### PR DESCRIPTION
This PR adds an alternative "forgot password" button to the text field toolbar shown above keyboard. The main button in that case is hidden by keyboard.