### PR TITLE
Replace SchibstedAccount.Result with Swift.Result

### DIFF
--- a/Source/Core/Networking/Result.swift
+++ b/Source/Core/Networking/Result.swift
@@ -8,18 +8,8 @@ import Foundation
 /// This is for the Result success type if no value is expected
 public typealias NoValue = ()
 
-/**
- A result object is generally used for asynchronous callbacks in the SDK
- */
-public enum Result<T, E: Error> {
-    /// Denotes a successful journey of bits and instructions through the virtual world.
-    /// Contains the value that was meant to be received in a success case.
-    case success(T)
-
-    /// Something went wrong. Contains the `Error` object with more information.
-    case failure(E)
-
-    func materialize() throws -> T {
+public extension Result {
+    func materialize() throws -> Success {
         switch self {
         case let .success(value): return value
         case let .failure(error): throw error

--- a/Source/UI/Coordinators/CompleteProfileCoordinator.swift
+++ b/Source/UI/Coordinators/CompleteProfileCoordinator.swift
@@ -222,7 +222,7 @@ extension CompleteProfileCoordinator {
     }
 
     private func handleFetchRequiredFieldsResult(
-        _ result: SchibstedAccount.Result<[RequiredField], ClientError>,
+        _ result: Result<[RequiredField], ClientError>,
         completion: @escaping (RequiredFieldEnteringResult) -> Void
     ) {
         switch result {


### PR DESCRIPTION
There's no need for a custom result type, and this avoids conflicting types in clients that integrate the SDK.