### PR TITLE
Changed: Fixed incorrect bundle usage in the SwiftPM package

### DIFF
--- a/Source/Core/SynchronizedDictionary.swift
+++ b/Source/Core/SynchronizedDictionary.swift
@@ -10,17 +10,17 @@ class SynchronizedDictionary<K: Hashable, V> {
     private let dispatchQueue = DispatchQueue(label: "com.schibsted.identity.SynchronizedDictionary", attributes: .concurrent)
 
     subscript(key: K) -> V? {
-        set {
-            dispatchQueue.async(flags: .barrier) {
-                self.dictionary[key] = newValue
-            }
-        }
         get {
             var value: V?
             dispatchQueue.sync {
                 value = self.dictionary[key]
             }
             return value
+        }
+        set {
+            dispatchQueue.async(flags: .barrier) {
+                self.dictionary[key] = newValue
+            }
         }
     }
 

--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -724,8 +724,12 @@ extension IdentityUI: TrackingEventsHandlerDelegate {
 }
 
 extension IdentityUI {
-    static let bundle = {
-        Bundle(for: IdentityUI.self)
+    static let bundle: Bundle = {
+        #if SWIFT_PACKAGE
+        return Bundle.module
+        #else
+        return Bundle(for: IdentityUI.self)
+        #endif
     }()
 }
 

--- a/Source/UI/IdentityUIViewController.swift
+++ b/Source/UI/IdentityUIViewController.swift
@@ -58,7 +58,12 @@ class IdentityUIViewController: UIViewController {
         self.trackerScreenID = trackerScreenID
         self.trackerViewAdditionalFields = trackerViewAdditionalFields
         let typeSelf = type(of: self)
-        super.init(nibName: typeSelf.nibName, bundle: Bundle(for: typeSelf))
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: typeSelf)
+        #endif
+        super.init(nibName: typeSelf.nibName, bundle: bundle)
     }
 
     required init?(coder _: NSCoder) {

--- a/Source/UI/Screens/CheckInbox/CheckInboxViewController.xib
+++ b/Source/UI/Screens/CheckInbox/CheckInboxViewController.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CheckInboxViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CheckInboxViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="changeButton" destination="G3X-hO-td0" id="pBV-Tw-IWy"/>
                 <outlet property="textLabel" destination="nMD-ag-4Zd" id="G56-bm-9bf"/>
@@ -23,25 +21,26 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="check-inbox" translatesAutoresizingMaskIntoConstraints="NO" id="pJi-Y3-Ucu">
-                    <rect key="frame" x="91" y="109" width="193" height="94"/>
+                    <rect key="frame" x="91" y="89" width="193" height="94"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="94" id="0RK-wQ-ci4"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMD-ag-4Zd" userLabel="SentLinkLabel" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                    <rect key="frame" x="166" y="260" width="42" height="21"/>
+                    <rect key="frame" x="167" y="240" width="41.5" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3X-hO-td0" userLabel="ChangeButton">
-                    <rect key="frame" x="164.5" y="281" width="46" height="30"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3X-hO-td0" userLabel="ChangeButton">
+                    <rect key="frame" x="164.5" y="260.5" width="46" height="30"/>
                     <state key="normal" title="Button"/>
                     <connections>
                         <action selector="didTapChangeButton:" destination="-1" eventType="touchUpInside" id="PES-yt-MCn"/>
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="pJi-Y3-Ucu" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="91" id="49G-Fp-6Fx"/>
@@ -53,7 +52,7 @@
                 <constraint firstItem="G3X-hO-td0" firstAttribute="top" secondItem="nMD-ag-4Zd" secondAttribute="bottom" id="q4T-XO-A82"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="G3X-hO-td0" secondAttribute="bottom" constant="16" id="qRX-Sp-mp9"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="140" y="155"/>
         </view>
     </objects>
     <resources>

--- a/Source/UI/Screens/CheckInbox/CheckInboxViewController.xib
+++ b/Source/UI/Screens/CheckInbox/CheckInboxViewController.xib
@@ -26,7 +26,7 @@
                         <constraint firstAttribute="height" constant="94" id="0RK-wQ-ci4"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMD-ag-4Zd" userLabel="SentLinkLabel" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMD-ag-4Zd" userLabel="SentLinkLabel" customClass="NormalLabel" customModule="SchibstedAccount">
                     <rect key="frame" x="167" y="240" width="41.5" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>

--- a/Source/UI/Screens/Error/ErrorViewController.xib
+++ b/Source/UI/Screens/Error/ErrorViewController.xib
@@ -34,19 +34,19 @@
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="250" image="location" translatesAutoresizingMaskIntoConstraints="NO" id="Wbb-TP-BLJ">
                                     <rect key="frame" x="0.0" y="0.0" width="311" height="72"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error asdas dasd as das dasd asd asd asd asd asd asd as" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jq9-Fj-Pjo" customClass="Heading" customModule="SchibstedAccount" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error asdas dasd as das dasd asd asd asd asd asd asd as" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jq9-Fj-Pjo" customClass="Heading" customModule="SchibstedAccount">
                                     <rect key="frame" x="0.0" y="88" width="311" height="41"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error description." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s95-xn-JM2" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error description." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s95-xn-JM2" customClass="NormalLabel" customModule="SchibstedAccount">
                                     <rect key="frame" x="0.0" y="145" width="311" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T1N-QZ-h0R" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T1N-QZ-h0R" customClass="PrimaryButton" customModule="SchibstedAccount">
                                     <rect key="frame" x="0.0" y="181.5" width="311" height="34"/>
                                     <state key="normal" title="OK">
                                         <color key="titleColor" red="0.0" green="0.50196081400000003" blue="1" alpha="1" colorSpace="calibratedRGB"/>

--- a/Source/UI/Screens/Error/ErrorViewController.xib
+++ b/Source/UI/Screens/Error/ErrorViewController.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ErrorViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ErrorViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="descriptionLabel" destination="s95-xn-JM2" id="Cmh-fh-lhk"/>
                 <outlet property="headingLabel" destination="Jq9-Fj-Pjo" id="B9a-Wv-dtg"/>
@@ -28,7 +26,7 @@
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bl0-tH-nXD" userLabel="stack background">
-                    <rect key="frame" x="16" y="209.5" width="343" height="248"/>
+                    <rect key="frame" x="16" y="210" width="343" height="247.5"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="cdj-im-QTv">
                             <rect key="frame" x="16" y="16" width="311" height="215.5"/>
@@ -69,6 +67,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="wZL-Vf-ece"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="bl0-tH-nXD" firstAttribute="top" relation="greaterThanOrEqual" secondItem="wZL-Vf-ece" secondAttribute="top" constant="16" id="1DC-yd-2EZ"/>
@@ -82,7 +81,7 @@
                 <constraint firstAttribute="trailing" secondItem="IIf-ES-tB9" secondAttribute="trailing" id="s5o-7q-bE0"/>
                 <constraint firstItem="wZL-Vf-ece" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bl0-tH-nXD" secondAttribute="bottom" constant="16" id="w6z-ef-qZc"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="wZL-Vf-ece"/>
+            <point key="canvasLocation" x="140" y="155"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>

--- a/Source/UI/Screens/Identifier/IdentifierViewController.xib
+++ b/Source/UI/Screens/Identifier/IdentifierViewController.xib
@@ -43,7 +43,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8xA-mk-L2J">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="THF-VM-JvY" customClass="LogoStackView" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="THF-VM-JvY" customClass="LogoStackView" customModule="SchibstedAccount">
                                                     <rect key="frame" x="16" y="16" width="343" height="18"/>
                                                 </stackView>
                                             </subviews>
@@ -57,7 +57,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JpK-Kl-xqq">
                                             <rect key="frame" x="0.0" y="50" width="375" height="44.5"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Teaser" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lKU-ue-rCx" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Teaser" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lKU-ue-rCx" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -74,7 +74,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dUX-Li-6fk">
                                             <rect key="frame" x="0.0" y="94.5" width="375" height="372.5"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MrD-sI-hSd" userLabel="InputTitle" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MrD-sI-hSd" userLabel="InputTitle" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="16" y="16" width="343" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -86,7 +86,7 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="E1A-Rx-9fe" userLabel="NumberStackView">
                                                             <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
                                                             <subviews>
-                                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-6C-iFm" userLabel="CountryCode" customClass="TextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-6C-iFm" userLabel="CountryCode" customClass="TextField" customModule="SchibstedAccount">
                                                                     <rect key="frame" x="0.0" y="0.0" width="81" height="34"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="81" id="NsR-5G-kTT"/>
@@ -94,19 +94,19 @@
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                 </textField>
-                                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZeN-LP-RPp" userLabel="PhoneNumber" customClass="TextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZeN-LP-RPp" userLabel="PhoneNumber" customClass="TextField" customModule="SchibstedAccount">
                                                                     <rect key="frame" x="85" y="0.0" width="258" height="34"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                 </textField>
                                                             </subviews>
                                                         </stackView>
-                                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-Pk-rYA" userLabel="EmailAddress" customClass="TextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-Pk-rYA" userLabel="EmailAddress" customClass="TextField" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="38" width="343" height="34"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <textInputTraits key="textInputTraits"/>
                                                         </textField>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ziq-TS-JKS" userLabel="InputError" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ziq-TS-JKS" userLabel="InputError" customClass="ErrorLabel" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="76" width="343" height="20.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -177,7 +177,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="O8h-Mw-dIo">
                     <rect key="frame" x="16" y="567" width="343" height="84"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kaw-tF-5AU" userLabel="ContinueButton" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kaw-tF-5AU" userLabel="ContinueButton" customClass="PrimaryButton" customModule="SchibstedAccount">
                             <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
                             <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" title="Continue">
@@ -187,7 +187,7 @@
                                 <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="2BA-JA-BIn"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vgv-mx-Qwz" userLabel="SkipButton" customClass="SecondaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vgv-mx-Qwz" userLabel="SkipButton" customClass="SecondaryButton" customModule="SchibstedAccount">
                             <rect key="frame" x="0.0" y="50" width="343" height="34"/>
                             <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" title="Continue">

--- a/Source/UI/Screens/Identifier/IdentifierViewController.xib
+++ b/Source/UI/Screens/Identifier/IdentifierViewController.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IdentifierViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IdentifierViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="backgroundView" destination="uXc-nc-9kX" id="RvX-Fd-iho"/>
                 <outlet property="continueButton" destination="kaw-tF-5AU" id="I7k-fI-X8s"/>
@@ -83,36 +81,33 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="OUS-mb-DSr" userLabel="InputStackView">
-                                                    <rect key="frame" x="16" y="40.5" width="343" height="88.5"/>
+                                                    <rect key="frame" x="16" y="40.5" width="343" height="96.5"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="E1A-Rx-9fe" userLabel="NumberStackView">
-                                                            <rect key="frame" x="0.0" y="0.0" width="343" height="30"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
                                                             <subviews>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-6C-iFm" userLabel="CountryCode" customClass="TextField" customModule="SchibstedAccount" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="81" height="30"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="81" height="34"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="81" id="NsR-5G-kTT"/>
                                                                     </constraints>
-                                                                    <nil key="textColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                 </textField>
                                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZeN-LP-RPp" userLabel="PhoneNumber" customClass="TextField" customModule="SchibstedAccount" customModuleProvider="target">
-                                                                    <rect key="frame" x="85" y="0.0" width="258" height="30"/>
-                                                                    <nil key="textColor"/>
+                                                                    <rect key="frame" x="85" y="0.0" width="258" height="34"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <textInputTraits key="textInputTraits"/>
                                                                 </textField>
                                                             </subviews>
                                                         </stackView>
                                                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-Pk-rYA" userLabel="EmailAddress" customClass="TextField" customModule="SchibstedAccount" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="34" width="343" height="30"/>
-                                                            <nil key="textColor"/>
+                                                            <rect key="frame" x="0.0" y="38" width="343" height="34"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <textInputTraits key="textInputTraits"/>
                                                         </textField>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ziq-TS-JKS" userLabel="InputError" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="68" width="343" height="20.5"/>
+                                                            <rect key="frame" x="0.0" y="76" width="343" height="20.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -120,18 +115,18 @@
                                                     </subviews>
                                                 </stackView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="cIa-P1-gNm" userLabel="PrivacyStackView">
-                                                    <rect key="frame" x="16" y="153" width="343" height="219.5"/>
+                                                    <rect key="frame" x="16" y="161" width="343" height="211.5"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="9Qw-VW-lWj">
                                                             <rect key="frame" x="0.0" y="0.0" width="343" height="57.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Info text" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CZp-Li-kvw">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="58" height="19.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="56.5" height="19.5"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="16"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hSi-bS-tNY" userLabel="HelpButton">
+                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hSi-bS-tNY" userLabel="HelpButton">
                                                                     <rect key="frame" x="0.0" y="27.5" width="52" height="30"/>
                                                                     <state key="normal" title="What is"/>
                                                                     <connections>
@@ -205,6 +200,7 @@
                     </subviews>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="XBd-Pu-wB3"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="uXc-nc-9kX" firstAttribute="width" secondItem="XBd-Pu-wB3" secondAttribute="width" id="55A-nQ-rSU"/>
@@ -216,7 +212,6 @@
                 <constraint firstItem="SyO-au-Era" firstAttribute="leading" secondItem="XBd-Pu-wB3" secondAttribute="leading" id="j5z-Ay-fFw"/>
                 <constraint firstItem="XBd-Pu-wB3" firstAttribute="bottom" secondItem="O8h-Mw-dIo" secondAttribute="bottom" constant="16" id="qnL-vZ-3wZ"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="XBd-Pu-wB3"/>
             <point key="canvasLocation" x="47" y="64.5"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Source/UI/Screens/Info/InfoViewController.xib
+++ b/Source/UI/Screens/Info/InfoViewController.xib
@@ -52,7 +52,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="H89-Om-ehF">
                                                     <rect key="frame" x="0.0" y="0.0" width="311" height="227.5"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="752" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C50-p2-Oen" customClass="Heading" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="752" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C50-p2-Oen" customClass="Heading" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="311" height="191"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -74,7 +74,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Bzv-nP-mbe">
                                                     <rect key="frame" x="0.0" y="283.5" width="311" height="34"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GJI-Ep-0LG" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GJI-Ep-0LG" customClass="PrimaryButton" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="311" height="34"/>
                                                             <state key="normal" title="OK">
                                                                 <color key="titleColor" red="0.0" green="0.50196081400000003" blue="1" alpha="1" colorSpace="calibratedRGB"/>

--- a/Source/UI/Screens/Info/InfoViewController.xib
+++ b/Source/UI/Screens/Info/InfoViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InfoViewController">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="InfoViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="headerLabel" destination="C50-p2-Oen" id="WrQ-Kn-R4F"/>
                 <outlet property="infoImage" destination="WXA-dw-n7f" id="EKV-Cr-oXW"/>
@@ -62,7 +62,7 @@
                                                             <rect key="frame" x="0.0" y="207" width="311" height="20.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="Info text" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fGD-Xo-XZV">
-                                                                    <rect key="frame" x="124.5" y="0.0" width="62.5" height="20.5"/>
+                                                                    <rect key="frame" x="124.5" y="0.0" width="62" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -107,6 +107,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="cA2-vB-iHV"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="TdO-Lx-7gf" secondAttribute="trailing" id="HJT-t9-Aro"/>
                 <constraint firstItem="mGy-Rh-1tb" firstAttribute="centerY" secondItem="rB6-DF-PzQ" secondAttribute="centerY" id="NlR-Rf-zNI"/>
@@ -119,7 +120,6 @@
                 <constraint firstItem="TdO-Lx-7gf" firstAttribute="leading" secondItem="rB6-DF-PzQ" secondAttribute="leading" id="reU-9C-R1x"/>
                 <constraint firstItem="mGy-Rh-1tb" firstAttribute="leading" secondItem="cA2-vB-iHV" secondAttribute="leading" constant="16" id="waM-ct-S9c"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="cA2-vB-iHV"/>
             <point key="canvasLocation" x="38" y="153"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Source/UI/Screens/Password/PasswordViewController.xib
+++ b/Source/UI/Screens/Password/PasswordViewController.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PasswordViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PasswordViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="ageLabel" destination="hOG-O4-h0f" id="rzQ-6m-vgC"/>
                 <outlet property="changeIdentifierButton" destination="84w-Ex-Aj1" id="hM8-Ek-B1r"/>
@@ -100,7 +100,7 @@
                                             <rect key="frame" x="0.0" y="105.66666666666666" width="374" height="119"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MrD-sI-hSd" userLabel="InputTitle" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="156.66666666666666" height="20.333333333333332"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="155.66666666666666" height="20.333333333333332"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -118,7 +118,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7fY-9N-sDh" userLabel="InfoLabel" customClass="InfoLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="98.666666666666686" width="97" height="20.333333333333329"/>
+                                                    <rect key="frame" x="0.0" y="98.666666666666686" width="96.666666666666671" height="20.333333333333329"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="lessThanOrEqual" constant="200" id="eEz-T8-JjI"/>
                                                     </constraints>
@@ -133,23 +133,23 @@
                                             </constraints>
                                         </stackView>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jKN-h3-Rvo" userLabel="PersistentLoginStackView">
-                                            <rect key="frame" x="0.0" y="244.66666666666671" width="256" height="50.333333333333343"/>
+                                            <rect key="frame" x="0.0" y="244.66666666666671" width="255" height="50.333333333333343"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yBM-ZA-4Yr" customClass="Checkbox" customModule="SchibstedAccount" customModuleProvider="target" colorLabel="IBBuiltInLabel-Yellow">
                                                     <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
                                                     <state key="normal" image="unchecked-box"/>
                                                 </button>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Dbi-NU-S7W">
-                                                    <rect key="frame" x="34" y="0.0" width="222" height="50.333333333333336"/>
+                                                    <rect key="frame" x="34" y="0.0" width="221" height="50.333333333333336"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Remember me on this device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wkg-ZJ-dE0" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="222" height="20.333333333333332"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="221" height="20.333333333333332"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gD8-Wz-pMF" userLabel="WhatThis">
-                                                            <rect key="frame" x="0.0" y="20.333333333333314" width="84" height="30"/>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gD8-Wz-pMF" userLabel="WhatThis">
+                                                            <rect key="frame" x="0.0" y="20.333333333333314" width="85" height="30"/>
                                                             <state key="normal" title="What's this?"/>
                                                             <connections>
                                                                 <action selector="didTapWhatLink:" destination="-1" eventType="touchUpInside" id="enF-sg-9Xg"/>
@@ -206,7 +206,7 @@
                                         <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="2BA-JA-BIn"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Hc-x6-psB" userLabel="ForgotPassword" customClass="SecondaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Hc-x6-psB" userLabel="ForgotPassword" customClass="SecondaryButton" customModule="SchibstedAccount" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="50" width="382" height="34"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                     <state key="normal" title="Button"/>
@@ -226,6 +226,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="zXX-ts-gA9"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="zXX-ts-gA9" firstAttribute="trailing" secondItem="RxY-ny-ztl" secondAttribute="trailing" id="5By-jx-XBT"/>
@@ -237,7 +238,6 @@
                 <constraint firstItem="RxY-ny-ztl" firstAttribute="top" secondItem="SyO-au-Era" secondAttribute="bottom" id="vfc-Nz-SRb"/>
                 <constraint firstItem="SyO-au-Era" firstAttribute="trailing" secondItem="zXX-ts-gA9" secondAttribute="trailing" id="xg4-6R-mew"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="zXX-ts-gA9"/>
             <point key="canvasLocation" x="31.884057971014496" y="63.586956521739133"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Source/UI/Screens/Password/PasswordViewController.xib
+++ b/Source/UI/Screens/Password/PasswordViewController.xib
@@ -54,7 +54,7 @@
                                                         <constraint firstAttribute="height" constant="20" id="lv9-68-jUs"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New account creation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="vs3-qr-nXX" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New account creation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="vs3-qr-nXX" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="30" y="9.9999999999999982" width="364" height="20.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -75,7 +75,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="iQC-b3-MLc">
                                     <rect key="frame" x="20" y="48" width="374" height="295"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You need to be at least 16 years old to create a Schibsted account" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hOG-O4-h0f" userLabel="AgeLabel" customClass="InfoLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You need to be at least 16 years old to create a Schibsted account" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hOG-O4-h0f" userLabel="AgeLabel" customClass="InfoLabel" customModule="SchibstedAccount">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="40.666666666666664"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -84,7 +84,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="9Ai-F7-ffm" userLabel="IdentifierStackView">
                                             <rect key="frame" x="0.0" y="60.666666666666671" width="374" height="25"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" text="user@example.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rIh-12-tAG" userLabel="IdentifierLabel" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" text="user@example.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rIh-12-tAG" userLabel="IdentifierLabel" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="350" height="25"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -99,25 +99,25 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="sRQ-2a-rnZ">
                                             <rect key="frame" x="0.0" y="105.66666666666666" width="374" height="119"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MrD-sI-hSd" userLabel="InputTitle" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter your password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MrD-sI-hSd" userLabel="InputTitle" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="155.66666666666666" height="20.333333333333332"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-Pk-rYA" userLabel="Password" customClass="PasswordTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-Pk-rYA" userLabel="Password" customClass="PasswordTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="28.333333333333343" width="374" height="34"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ziq-TS-JKS" userLabel="InputError" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ziq-TS-JKS" userLabel="InputError" customClass="ErrorLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="70.333333333333343" width="37.666666666666664" height="20.333333333333329"/>
                                                     <accessibility key="accessibilityConfiguration" label="8 characters"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7fY-9N-sDh" userLabel="InfoLabel" customClass="InfoLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7fY-9N-sDh" userLabel="InfoLabel" customClass="InfoLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="98.666666666666686" width="96.666666666666671" height="20.333333333333329"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="lessThanOrEqual" constant="200" id="eEz-T8-JjI"/>
@@ -135,14 +135,14 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="jKN-h3-Rvo" userLabel="PersistentLoginStackView">
                                             <rect key="frame" x="0.0" y="244.66666666666671" width="255" height="50.333333333333343"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yBM-ZA-4Yr" customClass="Checkbox" customModule="SchibstedAccount" customModuleProvider="target" colorLabel="IBBuiltInLabel-Yellow">
+                                                <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yBM-ZA-4Yr" customClass="Checkbox" customModule="SchibstedAccount" colorLabel="IBBuiltInLabel-Yellow">
                                                     <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
                                                     <state key="normal" image="unchecked-box"/>
                                                 </button>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Dbi-NU-S7W">
                                                     <rect key="frame" x="34" y="0.0" width="221" height="50.333333333333336"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Remember me on this device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wkg-ZJ-dE0" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Remember me on this device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wkg-ZJ-dE0" customClass="NormalLabel" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="221" height="20.333333333333332"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -196,7 +196,7 @@
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="mgx-9s-rIE">
                             <rect key="frame" x="16" y="16" width="382" height="84"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kaw-tF-5AU" userLabel="ContinueButton" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kaw-tF-5AU" userLabel="ContinueButton" customClass="PrimaryButton" customModule="SchibstedAccount">
                                     <rect key="frame" x="0.0" y="0.0" width="382" height="34"/>
                                     <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <state key="normal" title="Continue">
@@ -206,7 +206,7 @@
                                         <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="2BA-JA-BIn"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Hc-x6-psB" userLabel="ForgotPassword" customClass="SecondaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Hc-x6-psB" userLabel="ForgotPassword" customClass="SecondaryButton" customModule="SchibstedAccount">
                                     <rect key="frame" x="0.0" y="50" width="382" height="34"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                     <state key="normal" title="Button"/>

--- a/Source/UI/Screens/RequiredFields/RequiredFieldsViewController.xib
+++ b/Source/UI/Screens/RequiredFields/RequiredFieldsViewController.xib
@@ -33,7 +33,7 @@
                                         <constraint firstAttribute="height" constant="20" placeholder="YES" id="uL1-fy-98e"/>
                                     </constraints>
                                 </stackView>
-                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="B1X-CN-sF8" customClass="TextView" customModule="SchibstedAccount" customModuleProvider="target">
+                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="B1X-CN-sF8" customClass="TextView" customModule="SchibstedAccount">
                                     <rect key="frame" x="16" y="38" width="343" height="36"/>
                                     <attributedString key="attributedText">
                                         <fragment content="Info text">
@@ -65,7 +65,7 @@
                         <constraint firstItem="YG2-ap-J6Y" firstAttribute="top" secondItem="iev-hC-9g1" secondAttribute="top" id="xJI-V3-IlJ"/>
                     </constraints>
                 </scrollView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yqI-Ms-4ff" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yqI-Ms-4ff" customClass="PrimaryButton" customModule="SchibstedAccount">
                     <rect key="frame" x="16" y="621" width="343" height="30"/>
                     <state key="normal" title="Button"/>
                     <connections>

--- a/Source/UI/Screens/RequiredFields/RequiredFieldsViewController.xib
+++ b/Source/UI/Screens/RequiredFields/RequiredFieldsViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RequiredFieldsViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RequiredFieldsViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="continueButton" destination="yqI-Ms-4ff" id="vLZ-36-Ful"/>
                 <outlet property="requiredFieldsStackView" destination="f4L-Tl-jFz" id="SfA-Ds-t49"/>
@@ -38,7 +38,7 @@
                                     <attributedString key="attributedText">
                                         <fragment content="Info text">
                                             <attributes>
-                                                <font key="NSFont" size="17" name=".SFNSText"/>
+                                                <font key="NSFont" metaFont="system" size="17"/>
                                                 <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                             </attributes>
                                         </fragment>
@@ -65,7 +65,7 @@
                         <constraint firstItem="YG2-ap-J6Y" firstAttribute="top" secondItem="iev-hC-9g1" secondAttribute="top" id="xJI-V3-IlJ"/>
                     </constraints>
                 </scrollView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yqI-Ms-4ff" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yqI-Ms-4ff" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
                     <rect key="frame" x="16" y="621" width="343" height="30"/>
                     <state key="normal" title="Button"/>
                     <connections>
@@ -73,6 +73,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="7iN-Dn-spP"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="7iN-Dn-spP" firstAttribute="trailing" secondItem="yqI-Ms-4ff" secondAttribute="trailing" constant="16" id="EUL-wz-v7i"/>
@@ -84,7 +85,6 @@
                 <constraint firstItem="iev-hC-9g1" firstAttribute="trailing" secondItem="7iN-Dn-spP" secondAttribute="trailing" id="jpQ-kk-KqW"/>
                 <constraint firstItem="YG2-ap-J6Y" firstAttribute="width" secondItem="7iN-Dn-spP" secondAttribute="width" id="xTO-OE-4km"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="7iN-Dn-spP"/>
             <point key="canvasLocation" x="-76" y="153"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Source/UI/Screens/Resend/ResendViewController.xib
+++ b/Source/UI/Screens/Resend/ResendViewController.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ResendViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ResendViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="code" destination="fGD-Xo-XZV" id="DGL-ou-iuI"/>
                 <outlet property="edit" destination="Np1-PI-Lke" id="rAb-ZE-oHp"/>
@@ -65,13 +63,13 @@
                                                             <rect key="frame" x="0.0" y="136.5" width="311" height="41"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="The code was sent to:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fGD-Xo-XZV" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                                                    <rect key="frame" x="71.5" y="0.0" width="168.5" height="20.5"/>
+                                                                    <rect key="frame" x="72" y="0.0" width="167.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="+123" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sgj-sA-xIF" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                                                    <rect key="frame" x="136.5" y="20.5" width="38.5" height="20.5"/>
+                                                                    <rect key="frame" x="136.5" y="20.5" width="38" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -126,6 +124,7 @@
                     </constraints>
                 </view>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="cA2-vB-iHV"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="TdO-Lx-7gf" secondAttribute="trailing" id="HJT-t9-Aro"/>
                 <constraint firstItem="mGy-Rh-1tb" firstAttribute="centerY" secondItem="rB6-DF-PzQ" secondAttribute="centerY" id="NlR-Rf-zNI"/>
@@ -138,7 +137,7 @@
                 <constraint firstItem="TdO-Lx-7gf" firstAttribute="leading" secondItem="rB6-DF-PzQ" secondAttribute="leading" id="reU-9C-R1x"/>
                 <constraint firstItem="mGy-Rh-1tb" firstAttribute="leading" secondItem="cA2-vB-iHV" secondAttribute="leading" constant="16" id="waM-ct-S9c"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="cA2-vB-iHV"/>
+            <point key="canvasLocation" x="140" y="155"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>

--- a/Source/UI/Screens/Resend/ResendViewController.xib
+++ b/Source/UI/Screens/Resend/ResendViewController.xib
@@ -53,7 +53,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="H89-Om-ehF">
                                                     <rect key="frame" x="0.0" y="0.0" width="311" height="177.5"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="752" text="We sent you a new verification code" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C50-p2-Oen" customClass="Heading" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="752" text="We sent you a new verification code" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C50-p2-Oen" customClass="Heading" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="311" height="120.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -62,13 +62,13 @@
                                                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="248" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="llg-3d-DMz">
                                                             <rect key="frame" x="0.0" y="136.5" width="311" height="41"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="The code was sent to:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fGD-Xo-XZV" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="The code was sent to:" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fGD-Xo-XZV" customClass="NormalLabel" customModule="SchibstedAccount">
                                                                     <rect key="frame" x="72" y="0.0" width="167.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="+123" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sgj-sA-xIF" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" text="+123" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sgj-sA-xIF" customClass="NormalLabel" customModule="SchibstedAccount">
                                                                     <rect key="frame" x="136.5" y="20.5" width="38" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
@@ -81,7 +81,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Bzv-nP-mbe">
                                                     <rect key="frame" x="0.0" y="233.5" width="311" height="84"/>
                                                     <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GJI-Ep-0LG" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GJI-Ep-0LG" customClass="PrimaryButton" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="311" height="34"/>
                                                             <state key="normal" title="OK">
                                                                 <color key="titleColor" red="0.0" green="0.50196081400000003" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -90,7 +90,7 @@
                                                                 <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="sTA-PY-FWj"/>
                                                             </connections>
                                                         </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Np1-PI-Lke" customClass="SecondaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Np1-PI-Lke" customClass="SecondaryButton" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="50" width="311" height="34"/>
                                                             <state key="normal" title="Edit your phone number">
                                                                 <color key="titleColor" red="0.22206924855709076" green="0.4401949942111969" blue="0.83146572113037109" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>

--- a/Source/UI/Screens/Terms/TermsViewController.xib
+++ b/Source/UI/Screens/Terms/TermsViewController.xib
@@ -22,7 +22,7 @@
                 <outlet property="view" destination="lkB-DA-yRI" id="Ij9-hU-lrq"/>
             </connections>
         </placeholder>
-        <view contentMode="scaleToFill" id="lkB-DA-yRI" customClass="ViewContainingExtendedSubviews" customModule="SchibstedAccount" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="lkB-DA-yRI" customClass="ViewContainingExtendedSubviews" customModule="SchibstedAccount">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -35,7 +35,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HHS-o8-qe0">
                                     <rect key="frame" x="16" y="40" width="343" height="20.5"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtext" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-DI-uqU" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtext" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-DI-uqU" customClass="NormalLabel" customModule="SchibstedAccount">
                                             <rect key="frame" x="0.0" y="0.0" width="59" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -49,14 +49,14 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0Ub-gW-7pi" userLabel="Terms1StackView">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="57.5"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aKB-yQ-muL" userLabel="Term1Checkbox" customClass="Checkbox" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aKB-yQ-muL" userLabel="Term1Checkbox" customClass="Checkbox" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
                                                     <state key="normal" image="unchecked-box"/>
                                                 </button>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XZa-57-dmi">
                                                     <rect key="frame" x="34" y="0.0" width="309" height="57.5"/>
                                                     <subviews>
-                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c6t-Z1-YQW" userLabel="Term1Text" customClass="TextView" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c6t-Z1-YQW" userLabel="Term1Text" customClass="TextView" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="309" height="33"/>
                                                             <attributedString key="attributedText">
                                                                 <fragment content="Terms one">
@@ -67,7 +67,7 @@
                                                             </attributedString>
                                                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                         </textView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hz8-Vo-kCX" userLabel="Term1Error" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hz8-Vo-kCX" userLabel="Term1Error" customClass="ErrorLabel" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="37" width="309" height="20.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -80,14 +80,14 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="iXT-rL-2dg" userLabel="Terms2StackView">
                                             <rect key="frame" x="0.0" y="73.5" width="343" height="57.5"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="etL-Yi-5ZV" userLabel="Term2Checkbox" customClass="Checkbox" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="etL-Yi-5ZV" userLabel="Term2Checkbox" customClass="Checkbox" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
                                                     <state key="normal" image="unchecked-box"/>
                                                 </button>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="c4g-uQ-A7S">
                                                     <rect key="frame" x="34" y="0.0" width="309" height="57.5"/>
                                                     <subviews>
-                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Exj-RD-MBi" userLabel="Term2Text" customClass="TextView" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Exj-RD-MBi" userLabel="Term2Text" customClass="TextView" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="0.0" width="309" height="33"/>
                                                             <attributedString key="attributedText">
                                                                 <fragment content="Terms two">
@@ -98,7 +98,7 @@
                                                             </attributedString>
                                                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                         </textView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Va-90-S6Y" userLabel="Term2Error" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Va-90-S6Y" userLabel="Term2Error" customClass="ErrorLabel" customModule="SchibstedAccount">
                                                             <rect key="frame" x="0.0" y="37" width="309" height="20.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -130,7 +130,7 @@
                         <constraint firstAttribute="bottom" secondItem="tCZ-nC-j3g" secondAttribute="bottom" id="rOW-1z-Ycw"/>
                     </constraints>
                 </scrollView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YVB-ZH-yR9" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YVB-ZH-yR9" customClass="PrimaryButton" customModule="SchibstedAccount">
                     <rect key="frame" x="16" y="606" width="343" height="45"/>
                     <color key="backgroundColor" red="0.22212691605091095" green="0.44204810261726379" blue="0.83183133602142334" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <constraints>

--- a/Source/UI/Screens/Terms/TermsViewController.xib
+++ b/Source/UI/Screens/Terms/TermsViewController.xib
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TermsViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TermsViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="acceptButton" destination="YVB-ZH-yR9" id="BzM-A1-33F"/>
                 <outlet property="scrollView" destination="pDO-7b-Val" id="jOH-hF-Mk8"/>
@@ -38,7 +36,7 @@
                                     <rect key="frame" x="16" y="40" width="343" height="20.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtext" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l9P-DI-uqU" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="59.5" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="59" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -63,7 +61,7 @@
                                                             <attributedString key="attributedText">
                                                                 <fragment content="Terms one">
                                                                     <attributes>
-                                                                        <font key="NSFont" metaFont="system" size="14"/>
+                                                                        <font key="NSFont" metaFont="menu" size="14"/>
                                                                     </attributes>
                                                                 </fragment>
                                                             </attributedString>
@@ -94,7 +92,7 @@
                                                             <attributedString key="attributedText">
                                                                 <fragment content="Terms two">
                                                                     <attributes>
-                                                                        <font key="NSFont" metaFont="system" size="14"/>
+                                                                        <font key="NSFont" metaFont="menu" size="14"/>
                                                                     </attributes>
                                                                 </fragment>
                                                             </attributedString>
@@ -146,6 +144,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="sKq-p0-gP5"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="YVB-ZH-yR9" firstAttribute="leading" secondItem="sKq-p0-gP5" secondAttribute="leading" constant="16" id="31F-Yz-IDv"/>
@@ -157,7 +156,6 @@
                 <constraint firstItem="sKq-p0-gP5" firstAttribute="bottom" secondItem="YVB-ZH-yR9" secondAttribute="bottom" constant="16" id="h3q-9i-5yB"/>
                 <constraint firstItem="tCZ-nC-j3g" firstAttribute="width" secondItem="sKq-p0-gP5" secondAttribute="width" id="puR-o7-jzm"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="sKq-p0-gP5"/>
             <point key="canvasLocation" x="26.5" y="51.5"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>

--- a/Source/UI/Screens/Verify/VerifyViewController.xib
+++ b/Source/UI/Screens/Verify/VerifyViewController.xib
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VerifyViewController" customModule="SchibstedAccount" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VerifyViewController" customModule="SchibstedAccount">
             <connections>
                 <outlet property="changeIdentifier" destination="Dg2-1a-y2B" id="I7v-6U-YrW"/>
                 <outlet property="errorText" destination="Ktb-rh-s7n" id="g1s-af-FFE"/>
@@ -78,13 +75,13 @@
                                     <rect key="frame" x="16" y="126.5" width="343" height="34"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verification code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tcs-2F-vhB" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="128.5" height="34"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="34"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="xzi-Q5-w5v">
-                                            <rect key="frame" x="136.5" y="0.0" width="206.5" height="34"/>
+                                            <rect key="frame" x="136" y="0.0" width="207" height="34"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MGg-nk-u7J">
                                                     <rect key="frame" x="0.0" y="0.0" width="61" height="34"/>
@@ -171,7 +168,7 @@
                                             </constraints>
                                         </stackView>
                                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="error message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ktb-rh-s7n" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="-168.5" width="343" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -194,7 +191,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mBh-93-1WH">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mBh-93-1WH">
                                                     <rect key="frame" x="0.0" y="20.5" width="77" height="30"/>
                                                     <state key="normal" title="What's this"/>
                                                     <connections>
@@ -241,6 +238,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="una-cn-kts"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="Dxs-UK-nE3" firstAttribute="leading" secondItem="una-cn-kts" secondAttribute="leading" constant="16" id="8md-hB-f3t"/>
@@ -252,7 +250,7 @@
                 <constraint firstItem="gqM-JQ-Djo" firstAttribute="width" secondItem="una-cn-kts" secondAttribute="width" id="nph-Ia-kmn"/>
                 <constraint firstItem="una-cn-kts" firstAttribute="trailing" secondItem="Dxs-UK-nE3" secondAttribute="trailing" constant="16" id="yYS-b0-xUw"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="una-cn-kts"/>
+            <point key="canvasLocation" x="140" y="155"/>
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>

--- a/Source/UI/Screens/Verify/VerifyViewController.xib
+++ b/Source/UI/Screens/Verify/VerifyViewController.xib
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -38,7 +37,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fbP-oJ-lR6">
                                     <rect key="frame" x="16" y="48" width="343" height="54.5"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the verification code we sent to:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YFk-iY-SOK" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the verification code we sent to:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YFk-iY-SOK" customClass="NormalLabel" customModule="SchibstedAccount">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -47,7 +46,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="oRj-3o-gDu">
                                             <rect key="frame" x="0.0" y="20.5" width="343" height="34"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w81-Mu-1QB" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w81-Mu-1QB" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="97" height="34"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -74,7 +73,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hsG-cK-rLV">
                                     <rect key="frame" x="16" y="126.5" width="343" height="34"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verification code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tcs-2F-vhB" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Verification code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tcs-2F-vhB" customClass="NormalLabel" customModule="SchibstedAccount">
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="34"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -102,7 +101,7 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="bJc-Mw-ydc" userLabel="Code Stack View">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="45"/>
                                             <subviews>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="m8F-sh-ktT" customClass="ValidateTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="m8F-sh-ktT" customClass="ValidateTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="45" height="45"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.93725490199999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -112,7 +111,7 @@
                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="24"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 </textField>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uYl-sM-riV" customClass="ValidateTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uYl-sM-riV" customClass="ValidateTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="59.5" y="0.0" width="45" height="45"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.93725490199999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -122,7 +121,7 @@
                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="24"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 </textField>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tXw-Le-jpx" customClass="ValidateTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tXw-Le-jpx" customClass="ValidateTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="119" y="0.0" width="45" height="45"/>
                                                     <color key="backgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.94901960780000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -132,7 +131,7 @@
                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="24"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 </textField>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hvu-XM-Ij3" customClass="ValidateTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hvu-XM-Ij3" customClass="ValidateTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="179" y="0.0" width="45" height="45"/>
                                                     <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -142,7 +141,7 @@
                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="24"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 </textField>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="G12-yK-poy" customClass="ValidateTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="G12-yK-poy" customClass="ValidateTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="238.5" y="0.0" width="45" height="45"/>
                                                     <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -152,7 +151,7 @@
                                                     <fontDescription key="fontDescription" type="system" weight="thin" pointSize="24"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 </textField>
-                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NEZ-a4-fip" customClass="ValidateTextField" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NEZ-a4-fip" customClass="ValidateTextField" customModule="SchibstedAccount">
                                                     <rect key="frame" x="298" y="0.0" width="45" height="45"/>
                                                     <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -167,7 +166,7 @@
                                                 <constraint firstAttribute="height" constant="45" id="4z2-pu-BQY"/>
                                             </constraints>
                                         </stackView>
-                                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="error message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ktb-rh-s7n" customClass="ErrorLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="error message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ktb-rh-s7n" customClass="ErrorLabel" customModule="SchibstedAccount">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -178,14 +177,14 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="FPx-Er-W7F" userLabel="PersistentLoginStackView">
                                     <rect key="frame" x="16" y="253.5" width="135" height="50.5"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RH7-QP-Qbe" customClass="Checkbox" customModule="SchibstedAccount" customModuleProvider="target" colorLabel="IBBuiltInLabel-Yellow">
+                                        <button opaque="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RH7-QP-Qbe" customClass="Checkbox" customModule="SchibstedAccount" colorLabel="IBBuiltInLabel-Yellow">
                                             <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
                                             <state key="normal" image="unchecked-box"/>
                                         </button>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="to7-9D-bhT">
                                             <rect key="frame" x="38" y="0.0" width="97" height="50.5"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="69p-Gz-L0b" customClass="NormalLabel" customModule="SchibstedAccount" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="NormalLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="69p-Gz-L0b" customClass="NormalLabel" customModule="SchibstedAccount">
                                                     <rect key="frame" x="0.0" y="0.0" width="97" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -229,7 +228,7 @@
                         <constraint firstAttribute="trailing" secondItem="gqM-JQ-Djo" secondAttribute="trailing" id="aOK-4u-YAp"/>
                     </constraints>
                 </scrollView>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dxs-UK-nE3" customClass="PrimaryButton" customModule="SchibstedAccount" customModuleProvider="target">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dxs-UK-nE3" customClass="PrimaryButton" customModule="SchibstedAccount">
                     <rect key="frame" x="16" y="617" width="343" height="34"/>
                     <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <state key="normal" title="Verify"/>

--- a/Source/UI/Style/StyleIcons.swift
+++ b/Source/UI/Style/StyleIcons.swift
@@ -34,7 +34,11 @@ public enum StyleIconKind: String {
 
 extension UIImage {
     convenience init?(icon: StyleIconKind) {
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
         let bundle = Bundle(for: IdentityManager.self)
+        #endif
         self.init(named: icon.rawValue, in: bundle, compatibleWith: nil)
     }
 }

--- a/Source/UI/Views/LogoView.swift
+++ b/Source/UI/Views/LogoView.swift
@@ -12,7 +12,13 @@ class LogoStackView: UIStackView, Themeable {
 
         alignment = .center
 
-        let schImage = UIImage(named: "schibsted-logo", in: Bundle(for: IdentityUI.self), compatibleWith: nil)
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: IdentityUI.self)
+        #endif
+
+        let schImage = UIImage(named: "schibsted-logo", in: bundle, compatibleWith: nil)
         let schImageView = UIImageView(image: schImage)
         schImageView.contentMode = .scaleAspectFit
         schImageView.widthAnchor.constraint(equalToConstant: 69).isActive = true


### PR DESCRIPTION
#309 missed a few cases of `Bundle` usage for resources, which should use `Bundle.module` when targeting the SPM package.

I also had to remove `customModuleProvider="target"` from all the .xib files in order to ensure correct module targeting.