### PR TITLE
Save the username & password to the shared web credentials

### DIFF
--- a/Example/PasswordFlowViewController.swift
+++ b/Example/PasswordFlowViewController.swift
@@ -27,7 +27,7 @@ class PasswordFlowViewController: UIViewController {
 
     @IBAction func login(_: UIButton) {
         guard let email = self.email, let password = self.password else { return }
-        UIApplication.identityManager.login(email: email, password: password, scopes: ClientConfiguration.current.scopes, persistUser: shouldPersistUserSwitch.isOn) { result in
+        UIApplication.identityManager.login(email: email, password: password, scopes: ClientConfiguration.current.scopes, persistUser: shouldPersistUserSwitch.isOn, useSharedWebCredentials: true) { result in
             print(result)
         }
     }

--- a/Source/Manager/IdentityManager.swift
+++ b/Source/Manager/IdentityManager.swift
@@ -386,7 +386,7 @@ public class IdentityManager: IdentityManagerProtocol {
             return
         }
 
-        SecAddSharedWebCredential(clientConfiguration.serverURL.absoluteString as CFString,
+        SecAddSharedWebCredential(clientConfiguration.serverURL.host! as CFString,
                                   email.emailAddress as CFString,
                                   password as CFString) { error in
             if let error = error {

--- a/Source/Manager/IdentityManager.swift
+++ b/Source/Manager/IdentityManager.swift
@@ -387,8 +387,6 @@ public class IdentityManager: IdentityManagerProtocol {
             return
         }
 
-        let fqdn = clientConfiguration.serverURL.host!
-
         api.requestAccessToken(
             clientID: clientConfiguration.clientID,
             clientSecret: clientConfiguration.clientSecret,
@@ -397,7 +395,8 @@ public class IdentityManager: IdentityManagerProtocol {
             username: username.normalizedString,
             password: password,
             scope: (scopes + IdentityManager.defaultScopes).duplicatesRemoved()
-        ) { [weak self] result in
+        ) { [weak self, clientConfiguration] result in
+            let fqdn = clientConfiguration.serverURL.host!
             if case .success = result, useSharedWebCredentials {
                 SecAddSharedWebCredential(fqdn as CFString, email.emailAddress as CFString, password as CFString) { error in
                     if let error = error {

--- a/Source/Manager/IdentityManager.swift
+++ b/Source/Manager/IdentityManager.swift
@@ -381,9 +381,19 @@ public class IdentityManager: IdentityManagerProtocol {
             completion(result)
         }
 
-        guard case .email = username else {
+        guard case .email(let email) = username else {
             wrappedCompletion(.failure(ClientError.unexpectedIdentifier(actual: username, expected: "only EmailAddress supported")))
             return
+        }
+
+        SecAddSharedWebCredential(clientConfiguration.serverURL.absoluteString as CFString,
+                                  email.emailAddress as CFString,
+                                  password as CFString) { error in
+            if let error = error {
+                log(level: .error, from: self, "Failed to add \(username) to the shared web credentials: \(error)")
+            } else {
+                log(level: .verbose, from: self, "Add credentials to the shared web credentials for \(username)")
+            }
         }
 
         api.requestAccessToken(

--- a/Source/Manager/IdentityManager.swift
+++ b/Source/Manager/IdentityManager.swift
@@ -392,7 +392,7 @@ public class IdentityManager: IdentityManagerProtocol {
             if let error = error {
                 log(level: .error, from: self, "Failed to add \(username) to the shared web credentials: \(error)")
             } else {
-                log(level: .verbose, from: self, "Add credentials to the shared web credentials for \(username)")
+                log(level: .verbose, from: self, "Added credentials to the shared web credentials for \(username)")
             }
         }
 

--- a/Source/Manager/IdentityManagerOverloads.swift
+++ b/Source/Manager/IdentityManagerOverloads.swift
@@ -40,8 +40,8 @@ public extension IdentityManagerProtocol {
     }
 
     /// - SeeAlso: `IdentityManager.login(...)`
-    func login(email: EmailAddress, password: String, scopes: [String] = [], persistUser: Bool, completion: @escaping NoValueCallback) {
-        return login(username: Identifier(email), password: password, scopes: scopes, persistUser: persistUser, completion: completion)
+    func login(email: EmailAddress, password: String, scopes: [String] = [], persistUser: Bool, useSharedWebCredentials: Bool, completion: @escaping NoValueCallback) {
+        return login(username: Identifier(email), password: password, scopes: scopes, persistUser: persistUser, useSharedWebCredentials: useSharedWebCredentials, completion: completion)
     }
     /// - SeeAlso: `IdentityManager.signup(...)`
     func signup(email: EmailAddress, password: String, persistUser: Bool, completion: @escaping NoValueCallback) {

--- a/Source/Manager/Protocols/IdentityManagerProtocol.swift
+++ b/Source/Manager/Protocols/IdentityManagerProtocol.swift
@@ -26,7 +26,7 @@ public protocol IdentityManagerProtocol: AnyObject {
     func validate(oneTimeCode: String, for _: Identifier, scopes: [String], persistUser: Bool, completion: @escaping NoValueCallback)
 
     ///
-    func login(username: Identifier, password: String, scopes: [String], persistUser: Bool, completion: @escaping NoValueCallback)
+    func login(username: Identifier, password: String, scopes: [String], persistUser: Bool, useSharedWebCredentials: Bool, completion: @escaping NoValueCallback)
 
     ///
     func signup(

--- a/Source/UI/Coordinators/PasswordCoordinator.swift
+++ b/Source/UI/Coordinators/PasswordCoordinator.swift
@@ -45,7 +45,7 @@ class PasswordCoordinator: AuthenticationCoordinator, RouteHandler {
             return
         }
 
-        let useSharedWebCredentials = configuration.useSharedWebCredentials
+        let useSharedWebCredentials = configuration.enableSharedWebCredentials
 
         submit(
             password: password,
@@ -100,7 +100,7 @@ extension PasswordCoordinator {
             localizationBundle: configuration.localizationBundle
         )
         let viewController = PasswordViewController(configuration: configuration, navigationSettings: navigationSettings, viewModel: viewModel)
-        let useSharedWebCredentials = configuration.useSharedWebCredentials
+        let useSharedWebCredentials = configuration.enableSharedWebCredentials
         viewController.didRequestAction = { [weak self] action in
             switch action {
             case let .enter(password, shouldPersistUser):

--- a/Source/UI/Coordinators/PasswordCoordinator.swift
+++ b/Source/UI/Coordinators/PasswordCoordinator.swift
@@ -44,12 +44,16 @@ class PasswordCoordinator: AuthenticationCoordinator, RouteHandler {
             showPasswordView(for: input.identifier, on: input.loginFlowVariant, scopes: input.scopes, completion: completion)
             return
         }
+
+        let useSharedWebCredentials = configuration.useSharedWebCredentials
+
         submit(
             password: password,
             for: input.identifier,
             on: input.loginFlowVariant,
             persistUser: true,
             scopes: input.scopes,
+            useSharedWebCredentials: useSharedWebCredentials,
             completion: completion
         )
     }
@@ -96,10 +100,11 @@ extension PasswordCoordinator {
             localizationBundle: configuration.localizationBundle
         )
         let viewController = PasswordViewController(configuration: configuration, navigationSettings: navigationSettings, viewModel: viewModel)
+        let useSharedWebCredentials = configuration.useSharedWebCredentials
         viewController.didRequestAction = { [weak self] action in
             switch action {
             case let .enter(password, shouldPersistUser):
-                self?.submit(password: password, for: identifier, on: loginFlowVariant, persistUser: shouldPersistUser, scopes: scopes, completion: completion)
+                self?.submit(password: password, for: identifier, on: loginFlowVariant, persistUser: shouldPersistUser, scopes: scopes, useSharedWebCredentials: useSharedWebCredentials, completion: completion)
             case .changeIdentifier:
                 completion(.changeIdentifier)
             case .forgotPassword:
@@ -134,6 +139,7 @@ extension PasswordCoordinator {
         on loginFlowVariant: LoginMethod.FlowVariant,
         persistUser: Bool,
         scopes: [String],
+        useSharedWebCredentials: Bool,
         completion: @escaping (Output) -> Void
     ) {
         if loginFlowVariant == .signup {
@@ -142,7 +148,7 @@ extension PasswordCoordinator {
         }
 
         presentedViewController?.startLoading()
-        signinInteractor.login(username: identifier, password: password, scopes: scopes) { [weak self] result in
+        signinInteractor.login(username: identifier, password: password, scopes: scopes, useSharedWebCredentials: useSharedWebCredentials) { [weak self] result in
             self?.presentedViewController?.endLoading()
 
             switch result {

--- a/Source/UI/IdentityUIConfiguration.swift
+++ b/Source/UI/IdentityUIConfiguration.swift
@@ -8,6 +8,7 @@ import UIKit
 
 private struct Constants {
     static let BiometricsSettingsKey = "Identity.useBiometrics"
+    static let UseSharedWebCredentialsSettingsKey = "Identity.useSharedWebCredentials"
 }
 
 /**
@@ -29,6 +30,13 @@ public struct IdentityUIConfiguration {
     /// This determines whether the user wants to use biometric login, defaults to false
     public var useBiometrics: Bool {
         guard let value = Settings.value(forKey: Constants.BiometricsSettingsKey) as? Bool else {
+            return false
+        }
+        return value
+    }
+    /// This determines whether the user wants to use shared web credentials, defaults to false
+    public var useSharedWebCredentials: Bool {
+        guard let value = Settings.value(forKey: Constants.UseSharedWebCredentialsSettingsKey) as? Bool else {
             return false
         }
         return value
@@ -145,6 +153,15 @@ public struct IdentityUIConfiguration {
     public func useBiometrics(_ useBiometrics: Bool) {
         Settings.setValue(useBiometrics, forKey: Constants.BiometricsSettingsKey)
     }
+
+    /**
+     Call this to enable shared web credentials.
+
+     - parameter useBiometrics: If you want to enable shared web credentials.
+     */
+    public func useSharedWebCredentials(_ useSharedWebCredentials: Bool) {
+        Settings.setValue(useSharedWebCredentials, forKey: Constants.UseSharedWebCredentialsSettingsKey)
+    }
 }
 
 extension IdentityUIConfiguration: CustomStringConvertible {
@@ -154,6 +171,7 @@ extension IdentityUIConfiguration: CustomStringConvertible {
             + "\n\tskippable: \(isSkippable), "
             + "\n\tenableBiometrics: \(enableBiometrics), "
             + "\n\tuseBiometrics: \(useBiometrics), "
+            + "\n\tuseSharedWebCredentials: \(useSharedWebCredentials), "
             + "\n\ttracker: \(tracker != nil), "
             + "\n\tclient: \(clientConfiguration)\n)"
     }

--- a/Source/UI/IdentityUIConfiguration.swift
+++ b/Source/UI/IdentityUIConfiguration.swift
@@ -8,7 +8,6 @@ import UIKit
 
 private struct Constants {
     static let BiometricsSettingsKey = "Identity.useBiometrics"
-    static let UseSharedWebCredentialsSettingsKey = "Identity.useSharedWebCredentials"
 }
 
 /**
@@ -35,12 +34,7 @@ public struct IdentityUIConfiguration {
         return value
     }
     /// This determines whether the user wants to use shared web credentials, defaults to false
-    public var useSharedWebCredentials: Bool {
-        guard let value = Settings.value(forKey: Constants.UseSharedWebCredentialsSettingsKey) as? Bool else {
-            return false
-        }
-        return value
-    }
+    public let enableSharedWebCredentials: Bool
     /// This will be given the navigationController we use internally before we start presentation incase you want to customize
     /// certain aspects
     public let presentationHook: ((UIViewController) -> Void)?
@@ -81,6 +75,7 @@ public struct IdentityUIConfiguration {
      - parameter localizationBundle: If you have any custom localizations you want to use
      - parameter appName: If you want to customize the app name display in the UI
      - parameter enableBiometrics: If you want to enable authentication using biometrics
+     - parameter enableSharedWebCredentials: If you want to enable shared web credentials.
      */
     public init(
         clientConfiguration: ClientConfiguration,
@@ -88,6 +83,7 @@ public struct IdentityUIConfiguration {
         isCancelable: Bool = true,
         isSkippable: Bool = false,
         enableBiometrics: Bool = false,
+        enableSharedWebCredentials: Bool = false,
         disableWhatsThisButton: Bool = false,
         presentationHook: ((UIViewController) -> Void)? = nil,
         tracker: TrackingEventsHandler? = nil,
@@ -101,6 +97,7 @@ public struct IdentityUIConfiguration {
         self.presentationHook = presentationHook
         self.localizationBundle = localizationBundle ?? IdentityUI.bundle
         self.enableBiometrics = enableBiometrics
+        self.enableSharedWebCredentials = enableSharedWebCredentials
         self.tracker = tracker
         self.disableWhatsThisButton = disableWhatsThisButton
         if let appName = appName {
@@ -153,15 +150,6 @@ public struct IdentityUIConfiguration {
     public func useBiometrics(_ useBiometrics: Bool) {
         Settings.setValue(useBiometrics, forKey: Constants.BiometricsSettingsKey)
     }
-
-    /**
-     Call this to enable shared web credentials.
-
-     - parameter useBiometrics: If you want to enable shared web credentials.
-     */
-    public func useSharedWebCredentials(_ useSharedWebCredentials: Bool) {
-        Settings.setValue(useSharedWebCredentials, forKey: Constants.UseSharedWebCredentialsSettingsKey)
-    }
 }
 
 extension IdentityUIConfiguration: CustomStringConvertible {
@@ -171,7 +159,7 @@ extension IdentityUIConfiguration: CustomStringConvertible {
             + "\n\tskippable: \(isSkippable), "
             + "\n\tenableBiometrics: \(enableBiometrics), "
             + "\n\tuseBiometrics: \(useBiometrics), "
-            + "\n\tuseSharedWebCredentials: \(useSharedWebCredentials), "
+            + "\n\tenableSharedWebCredentials: \(enableSharedWebCredentials), "
             + "\n\ttracker: \(tracker != nil), "
             + "\n\tclient: \(clientConfiguration)\n)"
     }

--- a/Source/UI/Interactors/SigninInteractor.swift
+++ b/Source/UI/Interactors/SigninInteractor.swift
@@ -10,8 +10,8 @@ class SigninInteractor {
         self.identityManager = identityManager
     }
 
-    func login(username: Identifier, password: String, scopes: [String], completion: @escaping (Result<User, ClientError>) -> Void) {
-        identityManager.login(username: username, password: password, scopes: scopes, persistUser: false) { [weak self] result in
+    func login(username: Identifier, password: String, scopes: [String], useSharedWebCredentials: Bool, completion: @escaping (Result<User, ClientError>) -> Void) {
+        identityManager.login(username: username, password: password, scopes: scopes, persistUser: false, useSharedWebCredentials: useSharedWebCredentials) { [weak self] result in
             guard let strongSelf = self else { return }
             switch result {
             case .success:


### PR DESCRIPTION
This will give the user the option to save the username & password in the shared web credentials, so they can easily login on the related websites as well.

The user will be prompted _once_ with the following:

![](https://user-images.githubusercontent.com/233721/98681958-9c8aab00-2363-11eb-8a25-2206cc84e83f.PNG)

and when logging in with a different/updated password:

![](https://user-images.githubusercontent.com/233721/98681499-14a4a100-2363-11eb-9cf1-56a17fff42d6.PNG)

