### PR TITLE
Fixed crash when NSKeyedUnarchiver.unarchiveObject tried to unpack ObjC version of the SPiDAccessToken

### DIFF
--- a/Source/Manager/LegacySPiDAccessToken/SPiDKeychainWrapper.swift
+++ b/Source/Manager/LegacySPiDAccessToken/SPiDKeychainWrapper.swift
@@ -14,6 +14,7 @@ final class SPiDKeychainWrapper {
         var cfData: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &cfData)
         if status == noErr, let data = cfData as? Data {
+            NSKeyedUnarchiver.setClass(SPiDAccessToken.self, forClassName: "SPiDAccessToken")
             if let accessToken = NSKeyedUnarchiver.unarchiveObject(with: data) as? SPiDAccessToken {
                 return accessToken
             }


### PR DESCRIPTION
After the type was converted to Swift, the full type name changed, which could cause a crash unarchiving the ObjC type due to a type name mismatch.