### PR TITLE
New IdentityUIConfiguration option to be able to hide the persistent login checkbox

### DIFF
--- a/Source/UI/IdentityUIConfiguration.swift
+++ b/Source/UI/IdentityUIConfiguration.swift
@@ -45,6 +45,9 @@ public struct IdentityUIConfiguration {
 
     public let disableWhatsThisButton: Bool
 
+    /// This determines whether the persistent login checkbox should be hidden, defaults to false
+    public let hidePersistentLoginCheckbox: Bool
+
     /**
      Some of the UI screens will use the bundle name of your app. Sometimes this is not what you want
      so you can set this to override it
@@ -85,6 +88,7 @@ public struct IdentityUIConfiguration {
         enableBiometrics: Bool = false,
         enableSharedWebCredentials: Bool = false,
         disableWhatsThisButton: Bool = false,
+        hidePersistentLoginCheckbox: Bool = false,
         presentationHook: ((UIViewController) -> Void)? = nil,
         tracker: TrackingEventsHandler? = nil,
         localizationBundle: Bundle? = nil,
@@ -100,6 +104,7 @@ public struct IdentityUIConfiguration {
         self.enableSharedWebCredentials = enableSharedWebCredentials
         self.tracker = tracker
         self.disableWhatsThisButton = disableWhatsThisButton
+        self.hidePersistentLoginCheckbox = hidePersistentLoginCheckbox
         if let appName = appName {
             self.appName = appName
         }
@@ -124,6 +129,7 @@ public struct IdentityUIConfiguration {
         enableBiometrics: Bool? = nil,
         enableSharedWebCredentials: Bool? = nil,
         disableWhatsThisButton: Bool? = nil,
+        hidePersistentLoginCheckbox: Bool? = false,
         presentationHook: ((UIViewController) -> Void)? = nil,
         tracker: TrackingEventsHandler? = nil,
         localizationBundle: Bundle? = nil,
@@ -137,6 +143,7 @@ public struct IdentityUIConfiguration {
             enableBiometrics: enableBiometrics ?? self.enableBiometrics,
             enableSharedWebCredentials: enableSharedWebCredentials ?? self.enableSharedWebCredentials,
             disableWhatsThisButton: disableWhatsThisButton ?? self.disableWhatsThisButton,
+            hidePersistentLoginCheckbox: hidePersistentLoginCheckbox ?? self.hidePersistentLoginCheckbox,
             presentationHook: presentationHook ?? self.presentationHook,
             tracker: tracker ?? self.tracker,
             localizationBundle: localizationBundle ?? self.localizationBundle,

--- a/Source/UI/Screens/Password/PasswordViewController.swift
+++ b/Source/UI/Screens/Password/PasswordViewController.swift
@@ -131,6 +131,12 @@ class PasswordViewController: IdentityUIViewController {
         }
     }
 
+    @IBOutlet var persistentLoginStackView: UIStackView! {
+        didSet {
+            persistentLoginStackView.isHidden = configuration.hidePersistentLoginCheckbox
+        }
+    }
+
     let viewModel: PasswordViewModel
 
     init(configuration: IdentityUIConfiguration, navigationSettings: NavigationSettings, viewModel: PasswordViewModel) {

--- a/Source/UI/Screens/Password/PasswordViewController.xib
+++ b/Source/UI/Screens/Password/PasswordViewController.xib
@@ -23,6 +23,7 @@
                 <outlet property="newAccountCreateInfoLabel" destination="vs3-qr-nXX" id="pdR-4j-Q3d"/>
                 <outlet property="newAccountCreateNoticeHeader" destination="wmT-X1-CP5" id="ex6-sH-4FW"/>
                 <outlet property="password" destination="KeK-Pk-rYA" id="O2D-OQ-j1g"/>
+                <outlet property="persistentLoginStackView" destination="jKN-h3-Rvo" id="rA3-aT-pJd"/>
                 <outlet property="scrollView" destination="SyO-au-Era" id="wbw-WV-B6c"/>
                 <outlet property="shouldPersistUserCheck" destination="yBM-ZA-4Yr" id="EkY-Bi-wwo"/>
                 <outlet property="shouldPersistUserText" destination="Wkg-ZJ-dE0" id="bZc-i0-VYx"/>


### PR DESCRIPTION
This is a fix for old issue https://github.com/schibsted/account-sdk-ios/issues/189. There is a good explanation for why we (FINN) need this in there. We have been using a fork for a long time, but I think it is better if we can get this changed and eventually stop using a forked version.