### PR TITLE
Dark Mode support

### DIFF
--- a/Source/UI/IdentityUITheme.swift
+++ b/Source/UI/IdentityUITheme.swift
@@ -36,6 +36,8 @@ public struct IdentityUITheme {
         ///
         public var iconTint = UIColor.schibstedDarkGray
         ///
+        public var schibstedLogoTint = UIColor.schibstedBlack
+        ///
         public var barTintColor = UIColor.schibstedVeryLightGray
         ///
         public var checkedBox = UIColor.schibstedPrimary

--- a/Source/UI/Resources/Images.xcassets/back-arrow.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/back-arrow.imageset/Contents.json
@@ -1,23 +1,26 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
       "filename" : "arrow-back.png",
+      "idiom" : "universal",
       "scale" : "1x"
     },
     {
-      "idiom" : "universal",
       "filename" : "arrow-back@2x.png",
+      "idiom" : "universal",
       "scale" : "2x"
     },
     {
-      "idiom" : "universal",
       "filename" : "arrow-back@3x.png",
+      "idiom" : "universal",
       "scale" : "3x"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/chevron-left.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/chevron-left.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "keyboardArrowLeft.pdf"
+      "filename" : "keyboardArrowLeft.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/clear-input.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/clear-input.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "clear.pdf"
+      "filename" : "clear.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/cross.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/cross.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "close.pdf"
+      "filename" : "close.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/lock-outline.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/lock-outline.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "lock-outline.pdf"
+      "filename" : "lock-outline.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/password-hide.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/password-hide.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "password-hide.pdf"
+      "filename" : "password-hide.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/password-show.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/password-show.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "password-show.pdf"
+      "filename" : "password-show.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Resources/Images.xcassets/schibsted-logo.imageset/Contents.json
+++ b/Source/UI/Resources/Images.xcassets/schibsted-logo.imageset/Contents.json
@@ -1,12 +1,15 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "schibsted-logo.pdf"
+      "filename" : "schibsted-logo.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Source/UI/Screens/CheckInbox/CheckInboxViewController.xib
+++ b/Source/UI/Screens/CheckInbox/CheckInboxViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,7 +42,7 @@
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="pJi-Y3-Ucu" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="91" id="49G-Fp-6Fx"/>
                 <constraint firstItem="pJi-Y3-Ucu" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="89" id="5GM-aH-JXN"/>
@@ -57,5 +58,8 @@
     </objects>
     <resources>
         <image name="check-inbox" width="182" height="120"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Source/UI/Screens/Error/ErrorViewController.xib
+++ b/Source/UI/Screens/Error/ErrorViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,28 +27,27 @@
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bl0-tH-nXD" userLabel="stack background">
-                    <rect key="frame" x="16" y="210" width="343" height="247.5"/>
+                    <rect key="frame" x="16" y="238" width="343" height="191.5"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="cdj-im-QTv">
-                            <rect key="frame" x="16" y="16" width="311" height="215.5"/>
+                            <rect key="frame" x="16" y="16" width="311" height="159.5"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="250" image="location" translatesAutoresizingMaskIntoConstraints="NO" id="Wbb-TP-BLJ">
-                                    <rect key="frame" x="0.0" y="0.0" width="311" height="72"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="311" height="16"/>
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error asdas dasd as das dasd asd asd asd asd asd asd as" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jq9-Fj-Pjo" customClass="Heading" customModule="SchibstedAccount">
-                                    <rect key="frame" x="0.0" y="88" width="311" height="41"/>
+                                    <rect key="frame" x="0.0" y="32" width="311" height="41"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Error description." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s95-xn-JM2" customClass="NormalLabel" customModule="SchibstedAccount">
-                                    <rect key="frame" x="0.0" y="145" width="311" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="89" width="311" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T1N-QZ-h0R" customClass="PrimaryButton" customModule="SchibstedAccount">
-                                    <rect key="frame" x="0.0" y="181.5" width="311" height="34"/>
+                                    <rect key="frame" x="0.0" y="125.5" width="311" height="34"/>
                                     <state key="normal" title="OK">
                                         <color key="titleColor" red="0.0" green="0.50196081400000003" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     </state>
@@ -58,7 +58,7 @@
                             </subviews>
                         </stackView>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="cdj-im-QTv" secondAttribute="trailing" constant="16" id="8a7-9U-BGs"/>
                         <constraint firstAttribute="bottom" secondItem="cdj-im-QTv" secondAttribute="bottom" constant="16" id="TUe-La-9wd"/>
@@ -86,6 +86,9 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>
     <resources>
-        <image name="location" width="72" height="72"/>
+        <image name="location" width="16" height="16"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Source/UI/Screens/Identifier/IdentifierViewController.swift
+++ b/Source/UI/Screens/Identifier/IdentifierViewController.swift
@@ -27,11 +27,7 @@ class IdentifierViewController: IdentityUIViewController {
             whastThisButton.isHidden = configuration.disableWhatsThisButton
         }
     }
-    @IBOutlet var backgroundView: UIView! {
-        didSet {
-            backgroundView.backgroundColor = .schibstedLightGray
-        }
-    }
+    
     @IBAction func didTapWhatsThis(_: UIButton) {
         configuration.tracker?.engagement(.click(on: .whatsSchibstedAccount), in: trackerScreenID)
         didRequestAction?(.showHelp(url: viewModel.helpURL))

--- a/Source/UI/Screens/Identifier/IdentifierViewController.xib
+++ b/Source/UI/Screens/Identifier/IdentifierViewController.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IdentifierViewController" customModule="SchibstedAccount">
             <connections>
-                <outlet property="backgroundView" destination="uXc-nc-9kX" id="RvX-Fd-iho"/>
                 <outlet property="continueButton" destination="kaw-tF-5AU" id="I7k-fI-X8s"/>
                 <outlet property="countryCode" destination="0qS-6C-iFm" id="279-FZ-5dU"/>
                 <outlet property="emailAddress" destination="KeK-Pk-rYA" id="4Ji-Jh-VPe"/>
@@ -138,7 +138,7 @@
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             <constraints>
                                                 <constraint firstItem="OUS-mb-DSr" firstAttribute="top" secondItem="MrD-sI-hSd" secondAttribute="bottom" constant="4" id="2pB-1w-c8c"/>
                                                 <constraint firstItem="cIa-P1-gNm" firstAttribute="top" secondItem="OUS-mb-DSr" secondAttribute="bottom" constant="24" id="Dfa-Fm-xwa"/>
@@ -181,7 +181,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="343" height="34"/>
                             <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" title="Continue">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
                                 <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="2BA-JA-BIn"/>
@@ -191,7 +191,7 @@
                             <rect key="frame" x="0.0" y="50" width="343" height="34"/>
                             <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <state key="normal" title="Continue">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
                                 <action selector="didTapSubmitButton:" destination="-1" eventType="touchUpInside" id="Qwz-dV-Ao5"/>
@@ -201,7 +201,7 @@
                 </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="XBd-Pu-wB3"/>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="uXc-nc-9kX" firstAttribute="width" secondItem="XBd-Pu-wB3" secondAttribute="width" id="55A-nQ-rSU"/>
                 <constraint firstItem="SyO-au-Era" firstAttribute="top" secondItem="ETQ-ha-3W8" secondAttribute="top" id="GT1-SI-UoU"/>
@@ -216,4 +216,9 @@
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Source/UI/Screens/Info/InfoViewController.xib
+++ b/Source/UI/Screens/Info/InfoViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -98,7 +99,7 @@
                             </subviews>
                         </stackView>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="PtW-8I-W47" secondAttribute="trailing" id="OEg-EV-EhA"/>
                         <constraint firstItem="PtW-8I-W47" firstAttribute="top" secondItem="mGy-Rh-1tb" secondAttribute="top" id="Q9p-Ak-f3h"/>
@@ -124,4 +125,9 @@
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Source/UI/Screens/Password/PasswordViewController.swift
+++ b/Source/UI/Screens/Password/PasswordViewController.swift
@@ -83,7 +83,7 @@ class PasswordViewController: IdentityUIViewController {
             identifierLabel.text = viewModel.identifier.originalString
         }
     }
-    @IBOutlet var newAccountCreateInfoLabel: NormalLabel! {
+    @IBOutlet var newAccountCreateInfoLabel: UILabel! {
         didSet {
             newAccountCreateInfoLabel.text = viewModel.creatingNewAccountNotice
         }

--- a/Source/UI/Screens/Password/PasswordViewController.xib
+++ b/Source/UI/Screens/Password/PasswordViewController.xib
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_5" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -54,10 +55,10 @@
                                                         <constraint firstAttribute="height" constant="20" id="lv9-68-jUs"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New account creation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="vs3-qr-nXX" customClass="NormalLabel" customModule="SchibstedAccount">
-                                                    <rect key="frame" x="30" y="9.9999999999999982" width="364" height="20.333333333333329"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New account creation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="vs3-qr-nXX">
+                                                    <rect key="frame" x="30" y="10.333333333333334" width="364" height="19.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -169,7 +170,7 @@
                                     </constraints>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="iQC-b3-MLc" secondAttribute="bottom" constant="20" symbolic="YES" id="7Tt-1d-LCF"/>
                                 <constraint firstItem="wmT-X1-CP5" firstAttribute="leading" secondItem="uXc-nc-9kX" secondAttribute="leading" id="JgM-wL-anh"/>
@@ -200,7 +201,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="382" height="34"/>
                                     <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <state key="normal" title="Continue">
-                                        <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>
                                     <connections>
                                         <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="2BA-JA-BIn"/>
@@ -217,7 +218,7 @@
                             </subviews>
                         </stackView>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="mgx-9s-rIE" secondAttribute="bottom" constant="16" id="3yM-wI-Ae2"/>
                         <constraint firstAttribute="trailing" secondItem="mgx-9s-rIE" secondAttribute="trailing" constant="16" id="8fh-s1-aHU"/>
@@ -227,7 +228,7 @@
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="zXX-ts-gA9"/>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="zXX-ts-gA9" firstAttribute="trailing" secondItem="RxY-ny-ztl" secondAttribute="trailing" id="5By-jx-XBT"/>
                 <constraint firstItem="SyO-au-Era" firstAttribute="leading" secondItem="zXX-ts-gA9" secondAttribute="leading" id="Fds-Rv-c19"/>
@@ -246,5 +247,8 @@
         <image name="chevron-left" width="24" height="25"/>
         <image name="circular-info" width="23" height="23"/>
         <image name="unchecked-box" width="18" height="18"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Source/UI/Screens/RequiredFields/RequiredFieldsViewController.xib
+++ b/Source/UI/Screens/RequiredFields/RequiredFieldsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,19 +26,21 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YG2-ap-J6Y">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="150"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="150.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="f4L-Tl-jFz">
-                                    <rect key="frame" x="16" y="114" width="343" height="20"/>
+                                    <rect key="frame" x="16" y="114.5" width="343" height="20"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="20" placeholder="YES" id="uL1-fy-98e"/>
                                     </constraints>
                                 </stackView>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="B1X-CN-sF8" customClass="TextView" customModule="SchibstedAccount">
-                                    <rect key="frame" x="16" y="38" width="343" height="36"/>
+                                    <rect key="frame" x="16" y="38" width="343" height="36.5"/>
                                     <attributedString key="attributedText">
                                         <fragment content="Info text">
                                             <attributes>
+                                                <color key="NSBackgroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="NSColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <font key="NSFont" metaFont="system" size="17"/>
                                                 <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                             </attributes>
@@ -46,7 +49,7 @@
                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 </textView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="f4L-Tl-jFz" secondAttribute="trailing" constant="16" id="7jL-pV-ZZ5"/>
                                 <constraint firstItem="f4L-Tl-jFz" firstAttribute="top" secondItem="B1X-CN-sF8" secondAttribute="bottom" constant="40" id="PvX-0D-epX"/>
@@ -74,7 +77,7 @@
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="7iN-Dn-spP"/>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="7iN-Dn-spP" firstAttribute="trailing" secondItem="yqI-Ms-4ff" secondAttribute="trailing" constant="16" id="EUL-wz-v7i"/>
                 <constraint firstItem="7iN-Dn-spP" firstAttribute="bottom" secondItem="yqI-Ms-4ff" secondAttribute="bottom" constant="16" id="JhJ-Wg-NVb"/>
@@ -89,4 +92,9 @@
         </view>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Source/UI/Screens/Resend/ResendViewController.xib
+++ b/Source/UI/Screens/Resend/ResendViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,16 +29,16 @@
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mGy-Rh-1tb" userLabel="stack background">
-                    <rect key="frame" x="16" y="83" width="343" height="501.5"/>
+                    <rect key="frame" x="16" y="121" width="343" height="425.5"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="PtW-8I-W47">
-                            <rect key="frame" x="0.0" y="0.0" width="343" height="501.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="343" height="425.5"/>
                             <subviews>
                                 <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="iz1-ar-GAn">
-                                    <rect key="frame" x="0.0" y="0.0" width="343" height="136"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="343" height="60"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="740" image="placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="WXA-dw-n7f">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="136"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="60"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="lessThanOrEqual" constant="136" id="GJe-QU-1WX"/>
                                             </constraints>
@@ -45,7 +46,7 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" verticalHuggingPriority="248" translatesAutoresizingMaskIntoConstraints="NO" id="xHu-tU-CZc">
-                                    <rect key="frame" x="0.0" y="152" width="343" height="349.5"/>
+                                    <rect key="frame" x="0.0" y="76" width="343" height="349.5"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="56" translatesAutoresizingMaskIntoConstraints="NO" id="1fN-fS-XWB">
                                             <rect key="frame" x="16" y="16" width="311" height="317.5"/>
@@ -104,7 +105,7 @@
                                             </subviews>
                                         </stackView>
                                     </subviews>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstItem="1fN-fS-XWB" firstAttribute="leading" secondItem="xHu-tU-CZc" secondAttribute="leading" constant="16" id="2IT-W5-P5e"/>
                                         <constraint firstAttribute="trailing" secondItem="1fN-fS-XWB" secondAttribute="trailing" constant="16" id="4uk-kf-Dg8"/>
@@ -115,7 +116,7 @@
                             </subviews>
                         </stackView>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="PtW-8I-W47" secondAttribute="trailing" id="OEg-EV-EhA"/>
                         <constraint firstItem="PtW-8I-W47" firstAttribute="top" secondItem="mGy-Rh-1tb" secondAttribute="top" id="Q9p-Ak-f3h"/>
@@ -142,6 +143,9 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
     </objects>
     <resources>
-        <image name="placeholder" width="984" height="411"/>
+        <image name="placeholder" width="80" height="60"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Source/UI/Screens/Terms/TermsViewController.xib
+++ b/Source/UI/Screens/Terms/TermsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -111,7 +112,7 @@
                                     </subviews>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstItem="HHS-o8-qe0" firstAttribute="top" secondItem="tCZ-nC-j3g" secondAttribute="top" constant="40" id="2zu-NF-jGc"/>
                                 <constraint firstAttribute="trailing" secondItem="HHS-o8-qe0" secondAttribute="trailing" constant="16" id="B2u-Gj-YTY"/>
@@ -137,7 +138,7 @@
                         <constraint firstAttribute="height" constant="45" id="lLn-91-J9q"/>
                     </constraints>
                     <state key="normal" title="Accept">
-                        <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="didTapContinue:" destination="-1" eventType="touchUpInside" id="cli-pT-fk0"/>
@@ -145,7 +146,7 @@
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="sKq-p0-gP5"/>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="YVB-ZH-yR9" firstAttribute="leading" secondItem="sKq-p0-gP5" secondAttribute="leading" constant="16" id="31F-Yz-IDv"/>
                 <constraint firstItem="pDO-7b-Val" firstAttribute="trailing" secondItem="sKq-p0-gP5" secondAttribute="trailing" id="Eva-s3-u1a"/>
@@ -162,5 +163,8 @@
     </objects>
     <resources>
         <image name="unchecked-box" width="18" height="18"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Source/UI/Screens/Verify/VerifyViewController.xib
+++ b/Source/UI/Screens/Verify/VerifyViewController.xib
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -202,7 +204,7 @@
                                     </subviews>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="fbP-oJ-lR6" secondAttribute="trailing" constant="16" id="4i1-iw-Pev"/>
                                 <constraint firstItem="fbP-oJ-lR6" firstAttribute="top" secondItem="gqM-JQ-Djo" secondAttribute="top" constant="48" id="FX3-zH-JST"/>
@@ -231,14 +233,16 @@
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dxs-UK-nE3" customClass="PrimaryButton" customModule="SchibstedAccount">
                     <rect key="frame" x="16" y="617" width="343" height="34"/>
                     <color key="backgroundColor" red="0.23529411759999999" green="0.4823529412" blue="0.85490196080000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <state key="normal" title="Verify"/>
+                    <state key="normal" title="Verify">
+                        <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
                     <connections>
                         <action selector="didTapVerify:" destination="-1" eventType="touchUpInside" id="WGR-Vu-mpB"/>
                     </connections>
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="una-cn-kts"/>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="Dxs-UK-nE3" firstAttribute="leading" secondItem="una-cn-kts" secondAttribute="leading" constant="16" id="8md-hB-f3t"/>
                 <constraint firstItem="nWb-Tp-9xb" firstAttribute="trailing" secondItem="una-cn-kts" secondAttribute="trailing" id="Nej-nI-pXd"/>
@@ -255,5 +259,8 @@
     </objects>
     <resources>
         <image name="unchecked-box" width="18" height="18"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Source/UI/Utils/Utils.swift
+++ b/Source/UI/Utils/Utils.swift
@@ -69,22 +69,3 @@ extension String {
         return String(format: localizedString, arguments: vars)
     }
 }
-
-extension UIImage {
-    func resize(targetSize: CGSize) -> UIImage {
-        let size = self.size
-        let widthRatio = targetSize.width / size.width
-        let heightRatio = targetSize.height / size.height
-        let newSize = widthRatio > heightRatio ?
-            CGSize(width: size.width * heightRatio, height: size.height * heightRatio) :
-            CGSize(width: size.width * widthRatio, height: size.height * widthRatio)
-        let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
-
-        UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
-        draw(in: rect)
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        return newImage!
-    }
-}

--- a/Source/UI/Views/LogoView.swift
+++ b/Source/UI/Views/LogoView.swift
@@ -24,6 +24,7 @@ class LogoStackView: UIStackView, Themeable {
         schImageView.widthAnchor.constraint(equalToConstant: 69).isActive = true
         schImageView.heightAnchor.constraint(equalToConstant: 20).isActive = true
         schImageView.translatesAutoresizingMaskIntoConstraints = false
+        schImageView.tintColor = theme.colors.schibstedLogoTint
 
         let filler = UIView(frame: .zero)
         filler.translatesAutoresizingMaskIntoConstraints = false

--- a/Source/UI/Views/PasswordTextField.swift
+++ b/Source/UI/Views/PasswordTextField.swift
@@ -11,11 +11,13 @@ class PasswordTextField: TextField {
         super.applyTheme(theme: theme)
 
         let passwordVisibilityView = UIButton(type: .custom)
+        if #available(iOS 13.0, *) {
+            passwordVisibilityView.tintColor = .label
+        }
+
         passwordVisibilityView.contentEdgeInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: theme.geometry.groupedViewSpacing)
-        passwordVisibilityView.setImage(UIImage.schibstedPasswordShow.resize(targetSize: CGSize(width: 25, height: 25)), for: .normal)
-        passwordVisibilityView.frame = CGRect(x: 0, y: 0,
-                                              width: UIImage.schibstedPasswordShow.size.width + theme.geometry.groupedViewSpacing,
-                                              height: UIImage.schibstedPasswordShow.size.height)
+        passwordVisibilityView.setImage(UIImage.schibstedPasswordShow, for: .normal)
+        passwordVisibilityView.frame = CGRect(x: 0, y: 0, width: 25 + theme.geometry.groupedViewSpacing, height: 25)
         passwordVisibilityView.addTarget(self, action: #selector(togglePasswordVisibility), for: .touchUpInside)
 
         keyboardType = .default
@@ -33,10 +35,10 @@ class PasswordTextField: TextField {
 
     @IBAction private func togglePasswordVisibility(passwordVisibility: UIButton) {
         if isSecureTextEntry {
-            passwordVisibility.setImage(UIImage.schibstedPasswordHide.resize(targetSize: CGSize(width: 25, height: 25)), for: .normal)
+            passwordVisibility.setImage(UIImage.schibstedPasswordHide, for: .normal)
             isSecureTextEntry = false
         } else {
-            passwordVisibility.setImage(UIImage.schibstedPasswordShow.resize(targetSize: CGSize(width: 25, height: 25)), for: .normal)
+            passwordVisibility.setImage(UIImage.schibstedPasswordShow, for: .normal)
             isSecureTextEntry = true
         }
     }

--- a/Source/UI/Views/TextField.swift
+++ b/Source/UI/Views/TextField.swift
@@ -35,7 +35,7 @@ class TextField: UITextField, Themeable {
         layer.cornerRadius = theme.geometry.inputViewCornerRadius
         textColor = theme.colors.normalText
         // cursor color
-        tintColor = theme.colors.textInputCursor
+        tintColor = theme.colors.textInputCursor        
         contentInset = UIEdgeInsets(
             top: theme.geometry.groupedViewSpacing,
             left: 16,

--- a/Source/UI/Views/TextField.swift
+++ b/Source/UI/Views/TextField.swift
@@ -35,7 +35,7 @@ class TextField: UITextField, Themeable {
         layer.cornerRadius = theme.geometry.inputViewCornerRadius
         textColor = theme.colors.normalText
         // cursor color
-        tintColor = theme.colors.textInputCursor        
+        tintColor = theme.colors.textInputCursor
         contentInset = UIEdgeInsets(
             top: theme.geometry.groupedViewSpacing,
             left: 16,


### PR DESCRIPTION
Essential changes in order to support dark mode (iOS13+)

### Changes
- Replaced hardcoded `white` background with `systemBackground` in all xibs.
- Enabled templating for all icon assets
- Enabled custom tinting of the Schibsted logo in order to allow matching the `barTintColor` colour override.
- Removed unnecessary resizing of the show/hide password icon in order to support tinting. 
- Tweaked a few individual components that didn't need to change colour in dark mode.
