### PR TITLE
Pass the ClientError (if present) through the UserDelegate/IdentityManagerDelegate

### DIFF
--- a/Source/Manager/ClientError.swift
+++ b/Source/Manager/ClientError.swift
@@ -69,6 +69,12 @@ public enum ClientError: Error {
 
     /// Occurs when user does not have access to a requested resource (e.g. a product)
     case noAccess
+
+    /// Occours when the user refused to accept updated terms & conditions.
+    case userDidNotAcceptUpdatedTermsAndConditions
+
+    /// Occours when the user cancels the profile completion (i.e. when having to provide required fields)
+    case userCancelledProfileCompletion
 }
 
 public extension ClientError {
@@ -129,6 +135,10 @@ extension ClientError: CustomStringConvertible {
             return "Your password should have at least 8 characters."
         case .invalidDevicePayloadData:
             return "Invalid device payload data"
+        case .userDidNotAcceptUpdatedTermsAndConditions:
+            return "User did not accept updated terms & conditions."
+        case .userCancelledProfileCompletion:
+            return "User cancelled profile completion"
         }
     }
 }

--- a/Source/Manager/IdentityManager.swift
+++ b/Source/Manager/IdentityManager.swift
@@ -21,6 +21,19 @@ public protocol IdentityManagerDelegate: AnyObject {
      - SeeAlso: `UserDelegate.user(_:didChangeStateTo:)`
      */
     func userStateChanged(_ state: UserState)
+
+    /**
+     Informs you when the state of `IdentityManager.currentUser` changes due to an error
+
+     - SeeAlso: `UserDelegate.user(_:didChangeStateTo:error)`
+     */
+    func userStateChanged(_ state: UserState, error: ClientError)
+}
+
+public extension IdentityManagerDelegate {
+    func userStateChanged(_ state: UserState, error: ClientError) {
+        userStateChanged(state)
+    }
 }
 
 /**
@@ -776,6 +789,16 @@ extension IdentityManager: UserDelegate {
         DispatchQueue.main.async { [weak self] in
             log(from: self, "delegating state: \(newState)")
             self?.delegate?.userStateChanged(newState)
+        }
+    }
+
+    public func user(_ user: User, didChangeStateTo newState: UserState, error: ClientError) {
+        guard delegate != nil else {
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            log(from: self, "delegating state: \(newState), error: \(error)")
+            self?.delegate?.userStateChanged(newState, error: error)
         }
     }
 }

--- a/Source/Manager/TaskManager/TaskManager.swift
+++ b/Source/Manager/TaskManager/TaskManager.swift
@@ -241,10 +241,10 @@ class TaskManager {
                     case let .networkingError(internaleError):
                         let logoutCodes = [401, 403]
                         if case let NetworkingError.unexpectedStatus(status, _) = internaleError, logoutCodes.contains(status) {
-                            strongSelf.user?.logout()
+                            strongSelf.user?.logout(clientError: clientError)
                         }
                     case .invalidClientCredentials:
-                        strongSelf.user?.logout()
+                        strongSelf.user?.logout(clientError: clientError)
                     //
                     // HACK HACK HACK!
                     //
@@ -256,7 +256,7 @@ class TaskManager {
                     // cases. So for now we handle it here until someone thinks of a better way
                     //
                     case .invalidCode:
-                        strongSelf.user?.logout()
+                        strongSelf.user?.logout(clientError: clientError)
                     default:
                         break
                     }

--- a/Source/Manager/User/User.swift
+++ b/Source/Manager/User/User.swift
@@ -163,7 +163,11 @@ public class User: UserProtocol {
      If the user is already logged out nothing will happen. If not then the delegate will be informed of a state change.
      */
     public func logout() {
-        log(from: self, "state = \(state)")
+        logout(clientError: nil)
+    }
+
+    func logout(clientError: ClientError?) {
+        log(from: self, "state = \(state), clientError = \(clientError?.description ?? "<nil>")")
         guard let oldTokens = clearTokens() else {
             return
         }
@@ -175,7 +179,11 @@ public class User: UserProtocol {
             guard let value = weakVal.value else { return }
             if value.tokens == oldTokens {
                 if value.clearTokens() != nil {
-                    value.delegate?.user(value, didChangeStateTo: .loggedOut)
+                    if let clientError = clientError {
+                        value.delegate?.user(value, didChangeStateTo: .loggedOut, error: clientError)
+                    } else {
+                        value.delegate?.user(value, didChangeStateTo: .loggedOut)
+                    }
                 }
             }
         }

--- a/Source/Manager/User/UserDelegate.swift
+++ b/Source/Manager/User/UserDelegate.swift
@@ -11,4 +11,14 @@ public protocol UserDelegate: AnyObject {
      Is notified when the state of the user changes
      */
     func user(_ user: User, didChangeStateTo newState: UserState)
+    /**
+     Is notified when the state of the user changes due to an error
+     */
+    func user(_ user: User, didChangeStateTo newState: UserState, error: ClientError)
+}
+
+public extension UserDelegate {
+    func user(_ user: User, didChangeStateTo newState: UserState, error: ClientError) {
+        self.user(user, didChangeStateTo: newState)
+    }
 }

--- a/Source/UI/ClientError+localized.swift
+++ b/Source/UI/ClientError+localized.swift
@@ -40,7 +40,9 @@ extension ClientError {
              .userRefreshFailed,
              .invalidScope,
              .invalidDevicePayloadData,
-             .noAccess:
+             .noAccess,
+             .userDidNotAcceptUpdatedTermsAndConditions,
+             .userCancelledProfileCompletion:
             //
             // These do not have translations deliberately because they don't make sense to a user when trying to visually login, or
             // they are handled in some other way in the UI flows:

--- a/Source/UI/Coordinators/UpdatedTermsCoordinator.swift
+++ b/Source/UI/Coordinators/UpdatedTermsCoordinator.swift
@@ -53,7 +53,7 @@ extension UpdatedTermsCoordinator {
                 }
             case .cancel, .back:
                 // Since user has not accepted the updated terms, we force a logout :'(
-                userTermsInteractor.user.logout()
+                userTermsInteractor.user.logout(clientError: ClientError.userDidNotAcceptUpdatedTermsAndConditions)
                 completion(.cancel)
             }
         }

--- a/Source/UI/IdentityUI.swift
+++ b/Source/UI/IdentityUI.swift
@@ -527,7 +527,7 @@ extension IdentityUI {
                 func presentCompleteProfileCoordinator(user: User) {
                     let navigationController = DismissableNavigationController {
                         if IdentityUI.completeProfileCoordinator != nil {
-                            user.logout()
+                            user.logout(clientError: ClientError.userCancelledProfileCompletion)
                             completion(.cancel)
                         }
                         IdentityUI.completeProfileCoordinator = nil


### PR DESCRIPTION
Pass the client error (if any) through the `userStateChanged` delegate function(s) in order for the clients to receive the reason _why_ a particular user was logged out. 

The API changes are backwards compatible (protocol extensions making the new overload optional to implement)